### PR TITLE
✨ [Feat] 경기장 전체 조회 API 구현

### DIFF
--- a/scapture/src/main/java/com/server/scapture/image/repository/ImageRepository.java
+++ b/scapture/src/main/java/com/server/scapture/image/repository/ImageRepository.java
@@ -1,9 +1,13 @@
 package com.server.scapture.image.repository;
 
 import com.server.scapture.domain.Image;
+import com.server.scapture.domain.Stadium;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findFirst1ByStadium(Stadium stadium);
 }

--- a/scapture/src/main/java/com/server/scapture/stadium/controller/StadiumController.java
+++ b/scapture/src/main/java/com/server/scapture/stadium/controller/StadiumController.java
@@ -21,7 +21,7 @@ public class StadiumController {
         return stadiumService.createStadium(data, images);
     }
     @GetMapping
-    ResponseEntity<CustomAPIResponse<?>> getStadiums() {
-        return null;
+    ResponseEntity<CustomAPIResponse<?>> getStadiums(@RequestParam("city") String city, @RequestParam("state") String state) {
+        return stadiumService.getStadiumByCityAndState(city, state);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/stadium/dto/GetStadiumByCityAndStateResponseDto.java
+++ b/scapture/src/main/java/com/server/scapture/stadium/dto/GetStadiumByCityAndStateResponseDto.java
@@ -1,0 +1,19 @@
+package com.server.scapture.stadium.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+@Builder
+public class GetStadiumByCityAndStateResponseDto {
+    private Long stadiumId;
+    private String name;
+    private String location;
+    private String hours;
+    private boolean isOutside;
+    private String parking;
+    private String image;
+}

--- a/scapture/src/main/java/com/server/scapture/stadium/repository/StadiumRepository.java
+++ b/scapture/src/main/java/com/server/scapture/stadium/repository/StadiumRepository.java
@@ -4,9 +4,10 @@ import com.server.scapture.domain.Stadium;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface StadiumRepository extends JpaRepository<Stadium, Long> {
-    Optional<Stadium> findByCityAndState(String city, String state);
+    List<Stadium> findByCityAndState(String city, String state);
 }

--- a/scapture/src/main/java/com/server/scapture/stadium/repository/StadiumRepository.java
+++ b/scapture/src/main/java/com/server/scapture/stadium/repository/StadiumRepository.java
@@ -4,6 +4,9 @@ import com.server.scapture.domain.Stadium;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface StadiumRepository extends JpaRepository<Stadium, Long> {
+    Optional<Stadium> findByCityAndState(String city, String state);
 }

--- a/scapture/src/main/java/com/server/scapture/stadium/repository/StadiumRepository.java
+++ b/scapture/src/main/java/com/server/scapture/stadium/repository/StadiumRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface StadiumRepository extends JpaRepository<Stadium, Long> {
     List<Stadium> findByCityAndState(String city, String state);
+    List<Stadium> findByCity(String city);
 }

--- a/scapture/src/main/java/com/server/scapture/stadium/service/StadiumService.java
+++ b/scapture/src/main/java/com/server/scapture/stadium/service/StadiumService.java
@@ -11,4 +11,6 @@ import java.util.List;
 
 public interface StadiumService {
     ResponseEntity<CustomAPIResponse<?>> createStadium(CreateStadiumRequestDto data, List<MultipartFile> images) throws IOException;
+
+    ResponseEntity<CustomAPIResponse<?>> getStadiumByCityAndState(String city, String state);
 }

--- a/scapture/src/main/java/com/server/scapture/stadium/service/StadiumServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/stadium/service/StadiumServiceImpl.java
@@ -23,6 +23,8 @@ public class StadiumServiceImpl implements StadiumService{
     private final StadiumRepository stadiumRepository;
     private final ImageRepository imageRepository;
     private final S3Service s3Service;
+
+    // 관리자 - 경기장 생성
     @Override
     public ResponseEntity<CustomAPIResponse<?>> createStadium(CreateStadiumRequestDto data, List<MultipartFile> images) throws IOException {
         // 1. Stadium 생성
@@ -43,7 +45,6 @@ public class StadiumServiceImpl implements StadiumService{
         String dirName = stadium.getName();
         for (MultipartFile image : images) {
             String imageUrl = s3Service.upload(image, dirName);
-            System.out.println(imageUrl);
             Image stadiumImage = Image.builder()
                     .stadium(stadium)
                     .image(imageUrl)
@@ -62,4 +63,12 @@ public class StadiumServiceImpl implements StadiumService{
                 .status(HttpStatus.CREATED)
                 .body(responseBody);
     }
+    // Stadium - 경기장 조회
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> getStadiumByCityAndState(String city, String state) {
+        // 1. 조건에 맞는 Stadium 조회
+
+        return null;
+    }
+
 }

--- a/scapture/src/main/java/com/server/scapture/stadium/service/StadiumServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/stadium/service/StadiumServiceImpl.java
@@ -69,9 +69,13 @@ public class StadiumServiceImpl implements StadiumService{
     // Stadium - 경기장 조회
     @Override
     public ResponseEntity<CustomAPIResponse<?>> getStadiumByCityAndState(String city, String state) {
+        System.out.println(city + " " + state);
         // 1. 조건에 맞는 Stadium 조회
-        List<Stadium> foundStadiums = stadiumRepository.findByCityAndState(city, state);
-
+        List<Stadium> foundStadiums;
+        // 1-1. City 1개 조회
+        if(state.isEmpty()) foundStadiums = stadiumRepository.findByCity(city);
+        // 1-2. City State 2개 조회
+        else foundStadiums = stadiumRepository.findByCityAndState(city, state);
         // 2. Response
         // 2-1. data
         List<GetStadiumByCityAndStateResponseDto> data = new ArrayList<>();

--- a/scapture/src/main/java/com/server/scapture/user/JwtUtil.java
+++ b/scapture/src/main/java/com/server/scapture/user/JwtUtil.java
@@ -1,72 +1,72 @@
-package com.server.scapture.user;
-
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-import javax.crypto.SecretKey;
-import java.util.Date;
-
-@Slf4j
-@Component
-public class JwtUtil {
-    @Value("${jwt.secret}")
-    private String SECRET_KEY;
-
-    private SecretKey getSigningKey() {
-        byte[] keyBytes = Decoders.BASE64.decode(this.SECRET_KEY);
-        return Keys.hmacShaKeyFor(keyBytes);
-    }
-
-    // 액세스 토큰을 발급하는 메서드
-    public String generateAccessToken(Long userId, long expirationMillis) {
-        log.info("액세스 토큰이 발행되었습니다.");
-
-        return Jwts.builder()
-                .claim("userId", userId.toString()) // 클레임에 userId 추가
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + expirationMillis))
-                .signWith(this.getSigningKey())
-                .compact();
-    }
-
-    // 응답 헤더에서 액세스 토큰을 반환하는 메서드
-    public String getTokenFromHeader(String authorizationHeader) {
-        return authorizationHeader.substring(7);
-    }
-
-    // 토큰에서 유저 id를 반환하는 메서드
-    public String getUserIdFromToken(String token) {
-        try {
-            return Jwts.parserBuilder()
-                    .setSigningKey(this.getSigningKey())
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody()
-                    .get("userId", String.class);
-        } catch (JwtException | IllegalArgumentException e) {
-            log.warn("유효하지 않은 토큰입니다.");
-            return null;
-        }
-    }
-
-    // Jwt 토큰의 유효기간을 확인하는 메서드
-    public Boolean isTokenExpired(String token) {
-        try {
-            Date expirationDate = Jwts.parserBuilder()
-                    .setSigningKey(this.getSigningKey())
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody()
-                    .getExpiration();
-            return expirationDate.before(new Date());
-        } catch (JwtException | IllegalArgumentException e) {
-            log.warn("유효하지 않은 토큰입니다.");
-            return null;
-        }
-    }
-}
+//package com.server.scapture.user;
+//
+//import io.jsonwebtoken.JwtException;
+//import io.jsonwebtoken.Jwts;
+//import io.jsonwebtoken.io.Decoders;
+//import io.jsonwebtoken.security.Keys;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.stereotype.Component;
+//
+//import javax.crypto.SecretKey;
+//import java.util.Date;
+//
+//@Slf4j
+//@Component
+//public class JwtUtil {
+//    @Value("${jwt.secret}")
+//    private String SECRET_KEY;
+//
+//    private SecretKey getSigningKey() {
+//        byte[] keyBytes = Decoders.BASE64.decode(this.SECRET_KEY);
+//        return Keys.hmacShaKeyFor(keyBytes);
+//    }
+//
+//    // 액세스 토큰을 발급하는 메서드
+//    public String generateAccessToken(Long userId, long expirationMillis) {
+//        log.info("액세스 토큰이 발행되었습니다.");
+//
+//        return Jwts.builder()
+//                .claim("userId", userId.toString()) // 클레임에 userId 추가
+//                .setIssuedAt(new Date())
+//                .setExpiration(new Date(System.currentTimeMillis() + expirationMillis))
+//                .signWith(this.getSigningKey())
+//                .compact();
+//    }
+//
+//    // 응답 헤더에서 액세스 토큰을 반환하는 메서드
+//    public String getTokenFromHeader(String authorizationHeader) {
+//        return authorizationHeader.substring(7);
+//    }
+//
+//    // 토큰에서 유저 id를 반환하는 메서드
+//    public String getUserIdFromToken(String token) {
+//        try {
+//            return Jwts.parserBuilder()
+//                    .setSigningKey(this.getSigningKey())
+//                    .build()
+//                    .parseClaimsJws(token)
+//                    .getBody()
+//                    .get("userId", String.class);
+//        } catch (JwtException | IllegalArgumentException e) {
+//            log.warn("유효하지 않은 토큰입니다.");
+//            return null;
+//        }
+//    }
+//
+//    // Jwt 토큰의 유효기간을 확인하는 메서드
+//    public Boolean isTokenExpired(String token) {
+//        try {
+//            Date expirationDate = Jwts.parserBuilder()
+//                    .setSigningKey(this.getSigningKey())
+//                    .build()
+//                    .parseClaimsJws(token)
+//                    .getBody()
+//                    .getExpiration();
+//            return expirationDate.before(new Date());
+//        } catch (JwtException | IllegalArgumentException e) {
+//            log.warn("유효하지 않은 토큰입니다.");
+//            return null;
+//        }
+//    }
+//}

--- a/scapture/src/main/java/com/server/scapture/user/handler/OAuthLoginSuccessHandler.java
+++ b/scapture/src/main/java/com/server/scapture/user/handler/OAuthLoginSuccessHandler.java
@@ -1,105 +1,105 @@
-package com.server.scapture.user.handler;
-
-import com.server.scapture.domain.User;
-import com.server.scapture.user.JwtUtil;
-import com.server.scapture.user.dto.GoogleUserInfo;
-import com.server.scapture.user.dto.KakaoUserInfo;
-import com.server.scapture.user.dto.NaverUserInfo;
-import com.server.scapture.user.dto.OAuth2UserInfo;
-import com.server.scapture.user.repository.UserRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.server.scapture.util.response.CustomAPIResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
-import org.springframework.stereotype.Component;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-
-import java.io.IOException;
-import java.util.Map;
-
-@Slf4j
-@Component
-public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-
-    private final JwtUtil jwtUtil;
-    private final UserRepository userRepository;
-    private final String redirectUri;
-    private final long accessTokenExpirationTime;
-
-    public OAuthLoginSuccessHandler(
-            JwtUtil jwtUtil,
-            UserRepository userRepository,
-            @Value("${jwt.redirect}") String redirectUri,
-            @Value("${jwt.access-token.expiration-time}") long accessTokenExpirationTime) {
-        this.jwtUtil = jwtUtil;
-        this.userRepository = userRepository;
-        this.redirectUri = redirectUri;
-        this.accessTokenExpirationTime = accessTokenExpirationTime;
-    }
-
-    private OAuth2UserInfo oAuth2UserInfo = null;
-
-    @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
-        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication; // 토큰
-        final String provider = token.getAuthorizedClientRegistrationId(); // provider 추출
-
-        // 구글 || 카카오 || 네이버 로그인 요청
-        switch (provider) {
-            case "google" -> {
-                log.info("구글 로그인 요청");
-                oAuth2UserInfo = new GoogleUserInfo(token.getPrincipal().getAttributes());
-            }
-            case "kakao" -> {
-                log.info("카카오 로그인 요청");
-                oAuth2UserInfo = new KakaoUserInfo(token.getPrincipal().getAttributes());
-            }
-            case "naver" -> {
-                log.info("네이버 로그인 요청");
-                oAuth2UserInfo = new NaverUserInfo((Map<String, Object>) token.getPrincipal().getAttributes().get("response"));
-            }
-        }
-
-        // 정보 추출
-        String providerId = oAuth2UserInfo.getProviderId();
-        String name = oAuth2UserInfo.getName();
-
-        User existUser = userRepository.findByProviderId(providerId);
-        User user;
-
-        if (existUser == null) {
-            // 신규 유저인 경우
-            log.info("신규 유저입니다. 등록을 진행합니다.");
-
-            user = User.builder()
-                    .name(name)
-                    .provider(provider)
-                    .providerId(providerId)
-                    .build();
-            userRepository.save(user);
-        } else {
-            // 기존 유저인 경우
-            log.info("기존 유저입니다.");
-            user = existUser;
-        }
-
-        log.info("유저 이름 : {}", name);
-        log.info("PROVIDER : {}", provider);
-        log.info("PROVIDER_ID : {}", providerId);
-
-        // 액세스 토큰 발급
-        String accessToken = jwtUtil.generateAccessToken(user.getId(), accessTokenExpirationTime);
-
-        // 커스텀 응답 생성
-        CustomAPIResponse<Map<String, String>> customResponse = CustomAPIResponse.createSuccess(200, Map.of("token", accessToken), "카카오톡 로그인이 성공적으로 완료되었습니다.");
-
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        ObjectMapper objectMapper = new ObjectMapper();
-        response.getWriter().write(objectMapper.writeValueAsString(customResponse));
-    }
-}
+//package com.server.scapture.user.handler;
+//
+//import com.server.scapture.domain.User;
+//import com.server.scapture.user.JwtUtil;
+//import com.server.scapture.user.dto.GoogleUserInfo;
+//import com.server.scapture.user.dto.KakaoUserInfo;
+//import com.server.scapture.user.dto.NaverUserInfo;
+//import com.server.scapture.user.dto.OAuth2UserInfo;
+//import com.server.scapture.user.repository.UserRepository;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.server.scapture.util.response.CustomAPIResponse;
+//import jakarta.servlet.http.HttpServletRequest;
+//import jakarta.servlet.http.HttpServletResponse;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.security.core.Authentication;
+//import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+//import org.springframework.stereotype.Component;
+//import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+//
+//import java.io.IOException;
+//import java.util.Map;
+//
+//@Slf4j
+//@Component
+//public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+//
+//    private final JwtUtil jwtUtil;
+//    private final UserRepository userRepository;
+//    private final String redirectUri;
+//    private final long accessTokenExpirationTime;
+//
+//    public OAuthLoginSuccessHandler(
+//            JwtUtil jwtUtil,
+//            UserRepository userRepository,
+//            @Value("${jwt.redirect}") String redirectUri,
+//            @Value("${jwt.access-token.expiration-time}") long accessTokenExpirationTime) {
+//        this.jwtUtil = jwtUtil;
+//        this.userRepository = userRepository;
+//        this.redirectUri = redirectUri;
+//        this.accessTokenExpirationTime = accessTokenExpirationTime;
+//    }
+//
+//    private OAuth2UserInfo oAuth2UserInfo = null;
+//
+//    @Override
+//    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+//        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication; // 토큰
+//        final String provider = token.getAuthorizedClientRegistrationId(); // provider 추출
+//
+//        // 구글 || 카카오 || 네이버 로그인 요청
+//        switch (provider) {
+//            case "google" -> {
+//                log.info("구글 로그인 요청");
+//                oAuth2UserInfo = new GoogleUserInfo(token.getPrincipal().getAttributes());
+//            }
+//            case "kakao" -> {
+//                log.info("카카오 로그인 요청");
+//                oAuth2UserInfo = new KakaoUserInfo(token.getPrincipal().getAttributes());
+//            }
+//            case "naver" -> {
+//                log.info("네이버 로그인 요청");
+//                oAuth2UserInfo = new NaverUserInfo((Map<String, Object>) token.getPrincipal().getAttributes().get("response"));
+//            }
+//        }
+//
+//        // 정보 추출
+//        String providerId = oAuth2UserInfo.getProviderId();
+//        String name = oAuth2UserInfo.getName();
+//
+//        User existUser = userRepository.findByProviderId(providerId);
+//        User user;
+//
+//        if (existUser == null) {
+//            // 신규 유저인 경우
+//            log.info("신규 유저입니다. 등록을 진행합니다.");
+//
+//            user = User.builder()
+//                    .name(name)
+//                    .provider(provider)
+//                    .providerId(providerId)
+//                    .build();
+//            userRepository.save(user);
+//        } else {
+//            // 기존 유저인 경우
+//            log.info("기존 유저입니다.");
+//            user = existUser;
+//        }
+//
+//        log.info("유저 이름 : {}", name);
+//        log.info("PROVIDER : {}", provider);
+//        log.info("PROVIDER_ID : {}", providerId);
+//
+//        // 액세스 토큰 발급
+//        String accessToken = jwtUtil.generateAccessToken(user.getId(), accessTokenExpirationTime);
+//
+//        // 커스텀 응답 생성
+//        CustomAPIResponse<Map<String, String>> customResponse = CustomAPIResponse.createSuccess(200, Map.of("token", accessToken), "카카오톡 로그인이 성공적으로 완료되었습니다.");
+//
+//        response.setContentType("application/json");
+//        response.setCharacterEncoding("UTF-8");
+//        ObjectMapper objectMapper = new ObjectMapper();
+//        response.getWriter().write(objectMapper.writeValueAsString(customResponse));
+//    }
+//}

--- a/scapture/src/main/java/com/server/scapture/util/config/SecurityConfig.java
+++ b/scapture/src/main/java/com/server/scapture/util/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.server.scapture.util.config;
 
 import com.server.scapture.user.handler.OAuthLoginFailureHandler;
-import com.server.scapture.user.handler.OAuthLoginSuccessHandler;
+//import com.server.scapture.user.handler.OAuthLoginSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,7 +15,7 @@ import org.springframework.security.config.annotation.web.configurers.HttpBasicC
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
+//    private final OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
     private final OAuthLoginFailureHandler oAuthLoginFailureHandler;
 
     @Bean
@@ -26,12 +26,12 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize ->
                         authorize
                                 .requestMatchers("/**").permitAll()
-                )
-                .oauth2Login(oauth -> // OAuth2 로그인 기능에 대한 여러 설정의 진입점
-                        oauth
-                                .successHandler(oAuthLoginSuccessHandler) // 로그인 성공 시 핸들러
-                                .failureHandler(oAuthLoginFailureHandler) // 로그인 실패 시 핸들러
                 );
+//                .oauth2Login(oauth -> // OAuth2 로그인 기능에 대한 여러 설정의 진입점
+//                        oauth
+//                                .successHandler(oAuthLoginSuccessHandler) // 로그인 성공 시 핸들러
+//                                .failureHandler(oAuthLoginFailureHandler) // 로그인 실패 시 핸들러
+//                );
 
         return httpSecurity.build();
     }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #15 

### 📄 변경 사항
경기장 조회(시&지역) API 구현
경기장 조회(시) API 구현
Image 한 장만 뽑아오게 구현


### 🏆 테스트 결과
#### DB 상태
노원구: 3개, 성북구 1개
<img width="644" alt="image" src="https://github.com/user-attachments/assets/258a4daa-3a2e-4842-a6e8-7ae1028eaabf">

#### 경기장 조회(시&지역) API 구현
서울시&노원구 -> 노원구: 3개
<img width="1076" alt="image" src="https://github.com/user-attachments/assets/29d1a3ff-3699-49c6-b71f-fc4d70bbfafd">

#### 경기장 조회(시) API 구현
서울시 -> 노원구:3개, 성북구 1개
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/89c9d0ae-02e0-43d6-bcae-9e8c53054a31">


### Reviewer 요구 사항

