### PR TITLE
[FEAT] 카카오 소셜로그인 API 구현- 인가코드 받기, 접근 토큰 받기, 사용자 정보 받기

### DIFF
--- a/scapture/build.gradle
+++ b/scapture/build.gradle
@@ -43,6 +43,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5' // 최신 버전
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5' // 최신 버전
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // 최신 버전
+
+	//json
+	implementation 'org.json:json:20210307'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
 }
 
 tasks.named('test') {

--- a/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
@@ -1,4 +1,48 @@
 package com.server.scapture.oauth.controller;
 
+import com.server.scapture.oauth.service.SignService;
+import com.server.scapture.util.response.CustomAPIResponse;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("api/oauth")
+@RequiredArgsConstructor
 public class SignController {
+    private static final Logger logger = LoggerFactory.getLogger(SignController.class);
+    private final SignService signService;
+
+    //카카오 소셜 로그인
+    @PostMapping(value = "/social/kakao")
+    public ResponseEntity<CustomAPIResponse<?>> kakaoLogin(@RequestParam String code) {
+        // 1. 인가 코드 받기 (@RequestParam String code)
+
+        // 2. 접근 토큰 받기
+        String accessToken = signService.getAccessToken(code);
+        logger.info("Access Token: {}", accessToken);
+
+        // 3. 사용자 정보 받기
+        Map<String, Object> userInfo = signService.getUserInfo(accessToken);
+
+        String email = (String) userInfo.get("email");
+        String nickname = (String) userInfo.get("nickname");
+
+        logger.info("User Email: {}", email);
+        logger.info("User Nickname: {}", nickname);
+
+        // 필요한 로직 추가
+        // 4. 로그인
+
+        // 5. jwt 토큰 발급
+
+        return null;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
@@ -1,0 +1,4 @@
+package com.server.scapture.oauth.controller;
+
+public class SignController {
+}

--- a/scapture/src/main/java/com/server/scapture/oauth/dto/KakaoApi.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/dto/KakaoApi.java
@@ -1,0 +1,16 @@
+/*
+package com.server.scapture.oauth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Value;
+
+@Getter @Setter
+public class KakaoApi {
+    @Value("${KAKAO_CLIENT_ID}") -> 후에 오류 수정해야함
+    private String kakaoApiKey = "024871f91fe647ce7262bd022bd1afc2";
+
+    @Value("${KAKAO_REDIRECT_URI}")
+    private String kakaoRedirectUri = "http://localhost:3000/oauth/redirected/kakao";
+}
+*/

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignService.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignService.java
@@ -1,0 +1,11 @@
+package com.server.scapture.oauth.service;
+
+import java.util.Map;
+
+public interface SignService {
+    //카카오 소셜로그인 : 접근 토큰 받기
+    String getAccessToken(String code);
+
+    //카카오 소셜로그인 : 사용자 정보 받기
+    Map<String, Object> getUserInfo(String accessToken);
+}

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
@@ -1,0 +1,4 @@
+package com.server.scapture.oauth.service;
+
+public class SignServiceImpl {
+}

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
@@ -1,4 +1,137 @@
 package com.server.scapture.oauth.service;
 
-public class SignServiceImpl {
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class SignServiceImpl implements SignService {
+
+    private static final Logger logger = LoggerFactory.getLogger(SignServiceImpl.class);
+
+    @Override
+    public String getAccessToken(String code) {
+        String kakaoApiKey = "024871f91fe647ce7262bd022bd1afc2";
+        String kakaoRedirectUri = "http://localhost:3000/oauth/redirected/kakao";
+        String accessToken = "";
+        String reqUrl = "https://kauth.kakao.com/oauth/token";
+        String kakaoClientSecret = "8hIjcRxQfSSvvG8NV1nuksp9k2c9PEUP";
+        try {
+            URL url = new URL(reqUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            // 필수 헤더 세팅
+            conn.setRequestProperty("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+            conn.setDoOutput(true); // OutputStream으로 POST 데이터를 넘겨주겠다는 옵션.
+
+            // 필수 쿼리 파라미터 세팅
+            StringBuilder sb = new StringBuilder();
+            sb.append("grant_type=authorization_code");
+            sb.append("&client_id=").append(kakaoApiKey);
+            sb.append("&client_secret=").append(kakaoClientSecret);
+            sb.append("&redirect_uri=").append(kakaoRedirectUri);
+            sb.append("&code=").append(code);
+
+            // POST 데이터 전송
+            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
+            bw.write(sb.toString());
+            bw.flush();
+
+            // 응답 코드 확인
+            int responseCode = conn.getResponseCode();
+            logger.info("Token Response Code: {}", responseCode);
+
+            // 응답 읽기
+            BufferedReader br;
+            if (responseCode >= 200 && responseCode < 300) {
+                br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            } else {
+                br = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+            }
+
+            String line;
+            StringBuilder responseSb = new StringBuilder();
+            while ((line = br.readLine()) != null) {
+                responseSb.append(line);
+            }
+            String result = responseSb.toString();
+            logger.info("Token Response Body: {}", result);
+
+            // JSON 파싱
+            JSONObject jsonObject = new JSONObject(result);
+            if (jsonObject.has("access_token")) {
+                accessToken = jsonObject.getString("access_token");
+            } else {
+                logger.warn("No 'access_token' field in token response");
+            }
+
+            br.close();
+            bw.close();
+        } catch (Exception e) {
+            logger.error("Error getting access token", e);
+        }
+        return accessToken;
+    }
+
+
+    @Override
+    public HashMap<String, Object> getUserInfo(String accessToken) {
+        HashMap<String, Object> userInfo = new HashMap<>();
+        String reqUrl = "https://kapi.kakao.com/v2/user/me";
+        try {
+            URL url = new URL(reqUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+            conn.setRequestProperty("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            int responseCode = conn.getResponseCode();
+            logger.info("Response Code: {}", responseCode);
+
+            BufferedReader br;
+            if (responseCode >= 200 && responseCode <= 300) {
+                br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            } else {
+                br = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+            }
+
+            String line;
+            StringBuilder responseSb = new StringBuilder();
+            while ((line = br.readLine()) != null) {
+                responseSb.append(line);
+            }
+            String result = responseSb.toString();
+            logger.info("User Info Response Body: {}", result);
+
+            // JSON 파싱
+            JSONObject jsonObject = new JSONObject(result);
+            if (jsonObject.has("properties")) {
+                String nickname = jsonObject.getJSONObject("properties").getString("nickname");
+                userInfo.put("nickname", nickname);
+            } else {
+                logger.warn("No 'properties' field in response");
+            }
+            if (jsonObject.has("kakao_account")) {
+                String email = jsonObject.getJSONObject("kakao_account").getString("email");
+                userInfo.put("email", email);
+            } else {
+                logger.warn("No 'kakao_account' field in response");
+            }
+
+            br.close();
+
+        } catch (Exception e) {
+            logger.error("Error getting user info", e);
+        }
+        return userInfo;
+    }
 }

--- a/scapture/src/main/resources/application.properties
+++ b/scapture/src/main/resources/application.properties
@@ -27,6 +27,10 @@ jwt.redirect=${JWT_REDIRECT_URI}
 jwt.access-token.expiration-time=${ACCESS_TOKEN_EXPIRATION_TIME}
 jwt.refresh-token.expiration-time=${REFRESH_TOKEN_EXPIRATION_TIME}
 
+
+# log level
+logging.level.root=DEBUG
+
 # OAuth2 settings for Google
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}

--- a/scapture/src/main/resources/logback-spring.xml
+++ b/scapture/src/main/resources/logback-spring.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="CONSOLE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %highlight(%logger{36}) - %msg%n%ex{full}" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi> <!-- Jansi for Windows support -->
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
### 🌈 Issue 번호
- close #46 

### 📄 변경 사항
ex) Issue 내용 간단히 기재

### 🏆 테스트 결과
인가 코드 받기 -> 접근 토큰 받기 -> 사용자 정보 받기 
위 단계를 다 거쳐야 사용자 정보 받기 가능.
사용자 정보 받은 사진으로 테스트 대체 

최종 받은 사용자 정보 : 
<img width="544" alt="image" src="https://github.com/user-attachments/assets/9a2783cc-4e24-4f1d-934d-20b292e8bc79">

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/9f6e55d4-8a26-4a51-ac92-f35f9a156adc">
<img width="908" alt="image" src="https://github.com/user-attachments/assets/73986061-a48f-467c-b0c9-0be45abe15fd">
등

### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
