### PR TITLE
[Feat] 카카오 소셜로그인 API 관련 세팅- UserInfo Dto 생성, 회원 저장 관련 세팅

### DIFF
--- a/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
@@ -1,5 +1,6 @@
 package com.server.scapture.oauth.controller;
 
+import com.server.scapture.oauth.dto.UserInfo;
 import com.server.scapture.oauth.service.SignService;
 import com.server.scapture.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,16 +28,19 @@ public class SignController {
 
         // 2. 접근 토큰 받기
         String accessToken = signService.getAccessToken(code);
-        logger.info("Access Token: {}", accessToken);
+
+            //테스트 용도
+            logger.info("Access Token: {}", accessToken);
 
         // 3. 사용자 정보 받기
-        Map<String, Object> userInfo = signService.getUserInfo(accessToken);
+        UserInfo userInfo = signService.getUserInfo(accessToken);
 
-        String email = (String) userInfo.get("email");
-        String nickname = (String) userInfo.get("nickname");
+            //log를 통한 테스트 용도
 
-        logger.info("User Email: {}", email);
-        logger.info("User Nickname: {}", nickname);
+            logger.info("User_Email: {}", userInfo.getEmail());
+            logger.info("User_Nickname: {}", userInfo.getNickname());
+            logger.info("User_Id: {}", userInfo.getId());
+            logger.info("User_ProfileImage: {}", userInfo.getProfileImage());
 
         // 4. 로그인
 

--- a/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
@@ -38,7 +38,6 @@ public class SignController {
         logger.info("User Email: {}", email);
         logger.info("User Nickname: {}", nickname);
 
-        // 필요한 로직 추가
         // 4. 로그인
 
         // 5. jwt 토큰 발급

--- a/scapture/src/main/java/com/server/scapture/oauth/dto/UserInfo.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/dto/UserInfo.java
@@ -1,0 +1,13 @@
+package com.server.scapture.oauth.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UserInfo {
+    private long id;
+    private String nickname;
+    private String email;
+    private String profileImage;
+}

--- a/scapture/src/main/java/com/server/scapture/oauth/dto/UserInfo.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/dto/UserInfo.java
@@ -9,5 +9,6 @@ public class UserInfo {
     private long id;
     private String nickname;
     private String email;
+    // @Builder.Default //후에 기본값 지정해주기 -> 기본 카카오톡 프로필?
     private String profileImage;
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignService.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignService.java
@@ -1,5 +1,7 @@
 package com.server.scapture.oauth.service;
 
+import com.server.scapture.oauth.dto.UserInfo;
+
 import java.util.Map;
 
 public interface SignService {
@@ -7,5 +9,5 @@ public interface SignService {
     String getAccessToken(String code);
 
     //카카오 소셜로그인 : 사용자 정보 받기
-    Map<String, Object> getUserInfo(String accessToken);
+    UserInfo getUserInfo(String accessToken);
 }


### PR DESCRIPTION
### 🌈 Issue 번호
#52 

### 📄 변경 사항
회원가입/로그인을 위한 기능 추가 및 코드 구조 변경

### 🏆 테스트 결과
- 인가 코드 받기 > 접근 토큰 받기 > 회원 조회 > UserInfo Dto에 저장
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/306c91c5-a1a0-4838-a0d4-9e0daac70e16">

### Reviewer 요구 사항
