### PR TITLE
✨ [Feat] 카카오 소셜로그인 API 구현 - 로그인/회원가입

### DIFF
--- a/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
@@ -1,5 +1,6 @@
 package com.server.scapture.oauth.controller;
 
+import com.server.scapture.domain.User;
 import com.server.scapture.oauth.dto.UserInfo;
 import com.server.scapture.oauth.service.SignService;
 import com.server.scapture.util.response.CustomAPIResponse;
@@ -44,7 +45,7 @@ public class SignController {
             logger.info("User_Image: {}", userInfo.getImage());
 
         // 4. 로그인/회원가입
-        signService.login(userInfo);
+        User user = signService.login(userInfo);
 
         // 5. jwt 토큰 발급
 

--- a/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
@@ -33,14 +33,14 @@ public class SignController {
         String accessToken = signService.getAccessToken(code);
 
             //테스트 용도
-            logger.info("Access Token: {}", accessToken);
+            logger.info("Access_Token: {}", accessToken);
 
         // 3. 사용자 정보 받기
         UserInfo userInfo = signService.getUserInfo(accessToken);
 
             //log를 통한 테스트 용도
             logger.info("User_Email: {}", userInfo.getEmail());
-            logger.info("User_Nname: {}", userInfo.getName());
+            logger.info("User_Name: {}", userInfo.getName());
             logger.info("User_ProviderId: {}", userInfo.getProviderId());
             logger.info("User_Image: {}", userInfo.getImage());
 

--- a/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
@@ -24,6 +24,8 @@ public class SignController {
     //카카오 소셜 로그인
     @PostMapping(value = "/social/kakao")
     public ResponseEntity<CustomAPIResponse<?>> kakaoLogin(@RequestParam String code) {
+        // if문? 1번 실패 시 2~5번 진행 안 되도록 하는 로직 필요?
+
         // 1. 인가 코드 받기 (@RequestParam String code)
 
         // 2. 접근 토큰 받기
@@ -36,13 +38,13 @@ public class SignController {
         UserInfo userInfo = signService.getUserInfo(accessToken);
 
             //log를 통한 테스트 용도
-
             logger.info("User_Email: {}", userInfo.getEmail());
-            logger.info("User_Nickname: {}", userInfo.getNickname());
-            logger.info("User_Id: {}", userInfo.getId());
-            logger.info("User_ProfileImage: {}", userInfo.getProfileImage());
+            logger.info("User_Nname: {}", userInfo.getName());
+            logger.info("User_ProviderId: {}", userInfo.getProviderId());
+            logger.info("User_Image: {}", userInfo.getImage());
 
-        // 4. 로그인
+        // 4. 로그인/회원가입
+        signService.login(userInfo);
 
         // 5. jwt 토큰 발급
 

--- a/scapture/src/main/java/com/server/scapture/oauth/dto/UserInfo.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/dto/UserInfo.java
@@ -1,14 +1,29 @@
 package com.server.scapture.oauth.dto;
 
+import com.server.scapture.domain.Role;
+import com.server.scapture.domain.User;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
 public class UserInfo {
-    private long id;
-    private String nickname;
+    private String provider;
+    private String providerId;
+    private String name;
     private String email;
     // @Builder.Default //후에 기본값 지정해주기 -> 기본 카카오톡 프로필?
-    private String profileImage;
+    private String image;
+    private Role role;
+
+    public User toEntity() {
+        return User.builder()
+                .provider(provider)
+                .providerId(providerId)
+                .name(name)
+                .email(email)
+                .image(image)
+                .role(role)
+                .build();
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignService.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignService.java
@@ -1,5 +1,6 @@
 package com.server.scapture.oauth.service;
 
+import com.server.scapture.domain.User;
 import com.server.scapture.oauth.dto.UserInfo;
 import com.server.scapture.util.response.CustomAPIResponse;
 import org.springframework.http.ResponseEntity;
@@ -12,5 +13,5 @@ public interface SignService {
     UserInfo getUserInfo(String accessToken);
 
     //카카오 소셜로그인 : 로그인/회원가입
-    ResponseEntity<CustomAPIResponse<Object>> login(UserInfo userInfo);
+    User login(UserInfo userInfo);
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignService.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignService.java
@@ -1,8 +1,8 @@
 package com.server.scapture.oauth.service;
 
 import com.server.scapture.oauth.dto.UserInfo;
-
-import java.util.Map;
+import com.server.scapture.util.response.CustomAPIResponse;
+import org.springframework.http.ResponseEntity;
 
 public interface SignService {
     //카카오 소셜로그인 : 접근 토큰 받기
@@ -10,4 +10,7 @@ public interface SignService {
 
     //카카오 소셜로그인 : 사용자 정보 받기
     UserInfo getUserInfo(String accessToken);
+
+    //카카오 소셜로그인 : 로그인/회원가입
+    ResponseEntity<CustomAPIResponse<Object>> login(UserInfo userInfo);
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
@@ -4,13 +4,11 @@ import com.server.scapture.domain.Role;
 import com.server.scapture.domain.User;
 import com.server.scapture.oauth.dto.UserInfo;
 import com.server.scapture.user.repository.UserRepository;
-import com.server.scapture.util.response.CustomAPIResponse;
+import com.server.scapture.util.entity.OAuthException;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.io.*;
@@ -36,11 +34,9 @@ public class SignServiceImpl implements SignService {
             URL url = new URL(reqUrl);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
 
-            // 필수 헤더 세팅
             conn.setRequestProperty("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-            conn.setDoOutput(true); // OutputStream으로 POST 데이터를 넘겨주겠다는 옵션.
+            conn.setDoOutput(true);
 
-            // 필수 쿼리 파라미터 세팅
             StringBuilder sb = new StringBuilder();
             sb.append("grant_type=authorization_code");
             sb.append("&client_id=").append(kakaoApiKey);
@@ -48,47 +44,37 @@ public class SignServiceImpl implements SignService {
             sb.append("&redirect_uri=").append(kakaoRedirectUri);
             sb.append("&code=").append(code);
 
-            // POST 데이터 전송
-            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
-            bw.write(sb.toString());
-            bw.flush();
+            try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()))) {
+                bw.write(sb.toString());
+                bw.flush();
+            }
 
-            // 응답 코드 확인
             int responseCode = conn.getResponseCode();
             logger.info("Token Response Code: {}", responseCode);
 
-            // 응답 읽기
-            BufferedReader br;
-            if (responseCode >= 200 && responseCode < 300) {
-                br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-            } else {
-                br = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
-            }
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(
+                    responseCode >= 200 && responseCode < 300 ? conn.getInputStream() : conn.getErrorStream()))) {
+                String line;
+                StringBuilder responseSb = new StringBuilder();
+                while ((line = br.readLine()) != null) {
+                    responseSb.append(line);
+                }
+                String result = responseSb.toString();
+                logger.info("Token Response Body: {}", result);
 
-            String line;
-            StringBuilder responseSb = new StringBuilder();
-            while ((line = br.readLine()) != null) {
-                responseSb.append(line);
+                JSONObject jsonObject = new JSONObject(result);
+                if (jsonObject.has("access_token")) {
+                    accessToken = jsonObject.getString("access_token");
+                } else {
+                    throw new OAuthException("No 'access_token' field in token response");
+                }
             }
-            String result = responseSb.toString();
-            logger.info("Token Response Body: {}", result);
-
-            // JSON 파싱
-            JSONObject jsonObject = new JSONObject(result);
-            if (jsonObject.has("access_token")) {
-                accessToken = jsonObject.getString("access_token");
-            } else {
-                logger.warn("No 'access_token' field in token response");
-            }
-
-            br.close();
-            bw.close();
         } catch (Exception e) {
             logger.error("Error getting access token", e);
+            throw new OAuthException("Error getting access token");
         }
         return accessToken;
     }
-
 
     @Override
     public UserInfo getUserInfo(String accessToken) {
@@ -110,6 +96,10 @@ public class SignServiceImpl implements SignService {
             int responseCode = conn.getResponseCode();
             logger.info("Response Code: {}", responseCode);
 
+            if (responseCode == 401) { // Unauthorized - token expired or invalid
+                throw new OAuthException("Access token expired or invalid");
+            }
+
             try (BufferedReader br = new BufferedReader(new InputStreamReader(
                     responseCode >= 200 && responseCode <= 300 ? conn.getInputStream() : conn.getErrorStream()))) {
                 String line;
@@ -120,40 +110,27 @@ public class SignServiceImpl implements SignService {
                 String result = responseSb.toString();
                 logger.info("User Info Response Body: {}", result);
 
-                // JSON 파싱
                 JSONObject jsonObject = new JSONObject(result);
 
-                // ID 가져오기
                 if (jsonObject.has("id")) {
                     providerId = String.valueOf(jsonObject.getLong("id"));
                 } else {
                     logger.warn("No 'id' field in response");
                 }
 
-                // 닉네임 가져오기
                 if (jsonObject.has("properties")) {
-                    nickname = jsonObject.getJSONObject("properties").getString("nickname");
+                    nickname = jsonObject.getJSONObject("properties").optString("nickname", null);
                 } else {
                     logger.warn("No 'properties' field in response");
                 }
 
-                // 이메일 가져오기
                 if (jsonObject.has("kakao_account")) {
                     JSONObject kakaoAccount = jsonObject.getJSONObject("kakao_account");
-                    if (kakaoAccount.has("email")) {
-                        email = kakaoAccount.getString("email");
-                    } else {
-                        logger.warn("No 'email' field in 'kakao_account'");
-                    }
+                    email = kakaoAccount.optString("email", null);
 
-                    // 프로필 이미지 가져오기
                     if (kakaoAccount.has("profile")) {
                         JSONObject profile = kakaoAccount.getJSONObject("profile");
-                        if (profile.has("profile_image_url")) {
-                            profileImageUrl = profile.getString("profile_image_url");
-                        } else {
-                            logger.warn("No 'profile_image_url' field in 'profile'");
-                        }
+                        profileImageUrl = profile.optString("profile_image_url", null);
                     } else {
                         logger.warn("No 'profile' field in 'kakao_account'");
                     }
@@ -164,9 +141,11 @@ public class SignServiceImpl implements SignService {
 
         } catch (Exception e) {
             logger.error("Error getting user info", e);
+            throw new OAuthException("Error getting user info");
         }
 
         return UserInfo.builder()
+                .provider(provider)
                 .providerId(providerId)
                 .name(nickname)
                 .email(email)
@@ -175,23 +154,19 @@ public class SignServiceImpl implements SignService {
                 .build();
     }
 
-    //카카오 소셜로그인 : 로그인/회원가입
     @Override
     public User login(UserInfo userInfo) {
-        // 해당 provider, providerId를 가진 회원이 존재하는가 판별
-        String provider = userInfo.getProvider();
-        String providerId = userInfo.getProviderId();
+        Optional<User> foundUser = userRepository.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId());
 
-        Optional<User> foundUser = userRepository.findByProviderAndProviderId(provider, providerId);
-
-        // 회원가입 : 해당 회원이 존재하지 않을 시 -> 새로운 User 생성 후 리턴
         if (foundUser.isEmpty()) {
             User user = userInfo.toEntity();
             userRepository.save(user);
+            logger.info("User 회원가입 성공: {}", user.getName());
+            return user;
+        } else {
+            User user = foundUser.get();
+            logger.info("User 로그인 성공: {}", user.getName());
             return user;
         }
-
-        // 로그인 : 해당 회원이 존재할 시 -> 기존 User 리턴
-        return foundUser.get();
     }
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
@@ -158,12 +158,13 @@ public class SignServiceImpl implements SignService {
     public User login(UserInfo userInfo) {
         Optional<User> foundUser = userRepository.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId());
 
+        //회원가입
         if (foundUser.isEmpty()) {
             User user = userInfo.toEntity();
             userRepository.save(user);
             logger.info("User 회원가입 성공: {}", user.getName());
             return user;
-        } else {
+        } else { //로그인
             User user = foundUser.get();
             logger.info("User 로그인 성공: {}", user.getName());
             return user;

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
@@ -177,26 +177,21 @@ public class SignServiceImpl implements SignService {
 
     //카카오 소셜로그인 : 로그인/회원가입
     @Override
-    public ResponseEntity<CustomAPIResponse<Object>> login(UserInfo userInfo) {
+    public User login(UserInfo userInfo) {
         // 해당 provider, providerId를 가진 회원이 존재하는가 판별
         String provider = userInfo.getProvider();
         String providerId = userInfo.getProviderId();
 
         Optional<User> foundUser = userRepository.findByProviderAndProviderId(provider, providerId);
 
-        // 회원가입 : 해당 회원이 존재하지 않을 시
+        // 회원가입 : 해당 회원이 존재하지 않을 시 -> 새로운 User 생성 후 리턴
         if (foundUser.isEmpty()) {
             User user = userInfo.toEntity();
             userRepository.save(user);
+            return user;
         }
 
-        // 로그인 : 해당 회원이 존재할 시
-        UserLoginResponseDto data = UserLoginResponseDto.builder()
-                .user_id(user.getId())
-                .build();
-        CustomAPIResponse<UserLoginResponseDto> responseBody = CustomAPIResponse.createSuccess(HttpStatus.OK.value(), data, "로그인 성공 하였습니다.");
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(responseBody);
+        // 로그인 : 해당 회원이 존재할 시 -> 기존 User 리턴
+        return foundUser.get();
     }
 }

--- a/scapture/src/main/java/com/server/scapture/user/repository/UserRepository.java
+++ b/scapture/src/main/java/com/server/scapture/user/repository/UserRepository.java
@@ -4,7 +4,11 @@ import com.server.scapture.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     User findByProviderId(String providerId);
+
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/scapture/src/main/java/com/server/scapture/util/entity/OAuthException.java
+++ b/scapture/src/main/java/com/server/scapture/util/entity/OAuthException.java
@@ -1,0 +1,7 @@
+package com.server.scapture.util.entity;
+
+public class OAuthException extends RuntimeException {
+    public OAuthException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
### 🌈 Issue 번호
- close #52 

### 📄 변경 사항
- [x] 로그인/회원가입을 위한 getUserInfo 수정
- [x] 로그인 로직 구현
- [x] 회원가입 로직 구현
- [x] 간단한 예외처리 구현(테스트를 위해)

### 🏆 테스트 결과
ex) API의 경우 명세서에 기재된 사항들 Postman으로 테스트한 결과 첨부
1. 회원가입
- 로그
<img width="1155" alt="image" src="https://github.com/user-attachments/assets/b6be3512-6b9c-456d-8757-709ffbfadd2c">
- DB에 저장됨
<img width="600" alt="image" src="https://github.com/user-attachments/assets/a466f89f-07fe-48ce-bd37-76aaac29dd91">

2. 로그인
- 로그
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/78c95f40-5238-4148-a9fb-80ab65765fa0">
- db에 더 안 들어감
<img width="619" alt="image" src="https://github.com/user-attachments/assets/30bf0002-5648-4860-a1b2-91a02902ca89">

### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
