### PR TITLE
✨ 카카오 소셜로그인 - 예외처리 추가

### DIFF
--- a/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
@@ -54,8 +54,8 @@ public class SignController {
         logger.info("User_Image: {}", userInfo.getImage());
         ResponseEntity<CustomAPIResponse<?>> loginResponse = signService.login(userInfo);
         if (loginResponse.getBody().getStatus() != 200 || loginResponse.getBody().getStatus() != 201) {
-            return ResponseEntity.status(tokenResponse.getStatusCode()).body(tokenResponse.getBody());
+            return ResponseEntity.status(loginResponse.getStatusCode()).body(loginResponse.getBody());
         }
-        return ResponseEntity.status(tokenResponse.getStatusCode()).body(tokenResponse.getBody());
+        return ResponseEntity.status(loginResponse.getStatusCode()).body(loginResponse.getBody());
     }
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
@@ -7,13 +7,12 @@ import com.server.scapture.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("api/oauth")
@@ -25,30 +24,38 @@ public class SignController {
     //카카오 소셜 로그인
     @PostMapping(value = "/social/kakao")
     public ResponseEntity<CustomAPIResponse<?>> kakaoLogin(@RequestParam String code) {
-        // if문? 1번 실패 시 2~5번 진행 안 되도록 하는 로직 필요?
-
         // 1. 인가 코드 받기 (@RequestParam String code)
+        logger.info("Request_Code: {}", code);
+        if (code.isEmpty()) {
+            return ResponseEntity
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(CustomAPIResponse.createFailWithoutData(HttpStatus.FORBIDDEN.value(), "인가 코드를 전달받지 못했습니다."));
+        }
 
         // 2. 접근 토큰 받기
-        String accessToken = signService.getAccessToken(code);
-
-            //테스트 용도
-            logger.info("Access_Token: {}", accessToken);
+        ResponseEntity<CustomAPIResponse<?>> tokenResponse = signService.getAccessToken(code);
+        if (tokenResponse.getStatusCode() != HttpStatus.OK) {
+            return ResponseEntity.status(tokenResponse.getStatusCode()).body(tokenResponse.getBody());
+        }
 
         // 3. 사용자 정보 받기
-        UserInfo userInfo = signService.getUserInfo(accessToken);
+        String accessToken = (String) tokenResponse.getBody().getData(); //후에 서비스 계층 안으로 넣어주기
+        ResponseEntity<CustomAPIResponse<?>> userInfoResponse = signService.getUserInfo(accessToken);
+        if (userInfoResponse.getStatusCode() != HttpStatus.OK) {
+            return ResponseEntity.status(tokenResponse.getStatusCode()).body(tokenResponse.getBody());
+        }
 
-            //log를 통한 테스트 용도
-            logger.info("User_Email: {}", userInfo.getEmail());
-            logger.info("User_Name: {}", userInfo.getName());
-            logger.info("User_ProviderId: {}", userInfo.getProviderId());
-            logger.info("User_Image: {}", userInfo.getImage());
-
-        // 4. 로그인/회원가입
-        User user = signService.login(userInfo);
-
-        // 5. jwt 토큰 발급
-
-        return null;
+        // 4. 로그인/회원가입 후 JWT 토큰 발급
+        UserInfo userInfo = (UserInfo) userInfoResponse.getBody().getData(); //후에 서비스 계층 안으로 넣어주기
+        //log를 통한 테스트 용도
+        logger.info("User_Email: {}", userInfo.getEmail());
+        logger.info("User_Name: {}", userInfo.getName());
+        logger.info("User_ProviderId: {}", userInfo.getProviderId());
+        logger.info("User_Image: {}", userInfo.getImage());
+        ResponseEntity<CustomAPIResponse<?>> loginResponse = signService.login(userInfo);
+        if (loginResponse.getBody().getStatus() != 200 || loginResponse.getBody().getStatus() != 201) {
+            return ResponseEntity.status(tokenResponse.getStatusCode()).body(tokenResponse.getBody());
+        }
+        return ResponseEntity.status(tokenResponse.getStatusCode()).body(tokenResponse.getBody());
     }
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignService.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignService.java
@@ -7,11 +7,11 @@ import org.springframework.http.ResponseEntity;
 
 public interface SignService {
     //카카오 소셜로그인 : 접근 토큰 받기
-    String getAccessToken(String code);
+    ResponseEntity<CustomAPIResponse<?>> getAccessToken(String code);
 
     //카카오 소셜로그인 : 사용자 정보 받기
-    UserInfo getUserInfo(String accessToken);
+    ResponseEntity<CustomAPIResponse<?>> getUserInfo(String accessToken);
 
     //카카오 소셜로그인 : 로그인/회원가입
-    User login(UserInfo userInfo);
+    ResponseEntity<CustomAPIResponse<?>> login(UserInfo userInfo);
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
@@ -68,8 +68,8 @@ public class SignServiceImpl implements SignService {
                 if (jsonObject.has("access_token")) {
                     accessToken = jsonObject.getString("access_token");
                 } else {
-                    throw new OAuthException(" 'access_token' field in token response");
-                }
+                    CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401,"이미 사용되었거나 유효하지 않은 인가 코드 입니다.");
+                    return ResponseEntity.status(401).body(res);                }
             }
         } catch (Exception e) {
             logger.error("Error getting access token", e);

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
@@ -73,12 +73,12 @@ public class SignServiceImpl implements SignService {
             }
         } catch (Exception e) {
             logger.error("Error getting access token", e);
-            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401,"유효하지 않은 접근 토큰입니다.");
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401,"접근 토큰을 받는데 실패했습니다.");
             return ResponseEntity.status(401).body(res);
         }
 
         //성공 200 : 엑세스 토큰을 성공적으로 받은 경우
-        CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, accessToken, "엑세스 토큰을 성공적으로 받았습니다.");
+        CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, accessToken, "접근 토큰을 성공적으로 받았습니다.");
         return ResponseEntity.status(200).body(res);
     }
 
@@ -103,7 +103,7 @@ public class SignServiceImpl implements SignService {
             logger.info("Response Code: {}", responseCode);
 
             if (responseCode == 401) { // Unauthorized - token expired or invalid
-                CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401,"유효하지 않은 접근 토큰입니다.");
+                CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401,"토큰이 만료되었거나 유효하지 않은 토큰입니다.");
                 return ResponseEntity.status(401).body(res);
             }
 

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
@@ -5,10 +5,12 @@ import com.server.scapture.domain.User;
 import com.server.scapture.oauth.dto.UserInfo;
 import com.server.scapture.user.repository.UserRepository;
 import com.server.scapture.util.entity.OAuthException;
+import com.server.scapture.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.io.*;
@@ -24,10 +26,10 @@ public class SignServiceImpl implements SignService {
     private final UserRepository userRepository;
 
     @Override
-    public String getAccessToken(String code) {
+    public ResponseEntity<CustomAPIResponse<?>> getAccessToken(String code) {
         String kakaoApiKey = "024871f91fe647ce7262bd022bd1afc2";
         String kakaoRedirectUri = "http://localhost:3000/oauth/redirected/kakao";
-        String accessToken = "";
+        String accessToken;
         String reqUrl = "https://kauth.kakao.com/oauth/token";
         String kakaoClientSecret = "8hIjcRxQfSSvvG8NV1nuksp9k2c9PEUP";
         try {
@@ -66,18 +68,22 @@ public class SignServiceImpl implements SignService {
                 if (jsonObject.has("access_token")) {
                     accessToken = jsonObject.getString("access_token");
                 } else {
-                    throw new OAuthException("No 'access_token' field in token response");
+                    throw new OAuthException(" 'access_token' field in token response");
                 }
             }
         } catch (Exception e) {
             logger.error("Error getting access token", e);
-            throw new OAuthException("Error getting access token");
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401,"유효하지 않은 접근 토큰입니다.");
+            return ResponseEntity.status(401).body(res);
         }
-        return accessToken;
+
+        //성공 200 : 엑세스 토큰을 성공적으로 받은 경우
+        CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, accessToken, "엑세스 토큰을 성공적으로 받았습니다.");
+        return ResponseEntity.status(200).body(res);
     }
 
     @Override
-    public UserInfo getUserInfo(String accessToken) {
+    public ResponseEntity<CustomAPIResponse<?>> getUserInfo(String accessToken) {
         String providerId = null;
         String provider = "kakao";
         String nickname = null;
@@ -97,7 +103,8 @@ public class SignServiceImpl implements SignService {
             logger.info("Response Code: {}", responseCode);
 
             if (responseCode == 401) { // Unauthorized - token expired or invalid
-                throw new OAuthException("Access token expired or invalid");
+                CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401,"유효하지 않은 접근 토큰입니다.");
+                return ResponseEntity.status(401).body(res);
             }
 
             try (BufferedReader br = new BufferedReader(new InputStreamReader(
@@ -112,7 +119,7 @@ public class SignServiceImpl implements SignService {
 
                 JSONObject jsonObject = new JSONObject(result);
 
-                if (jsonObject.has("id")) {
+                if (jsonObject.has("id")) { //providerId
                     providerId = String.valueOf(jsonObject.getLong("id"));
                 } else {
                     logger.warn("No 'id' field in response");
@@ -141,10 +148,11 @@ public class SignServiceImpl implements SignService {
 
         } catch (Exception e) {
             logger.error("Error getting user info", e);
-            throw new OAuthException("Error getting user info");
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(400,"유저 정보를 가져오는데 실패했습니다.");
+            return ResponseEntity.status(400).body(res);
         }
 
-        return UserInfo.builder()
+        UserInfo userInfo = UserInfo.builder()
                 .provider(provider)
                 .providerId(providerId)
                 .name(nickname)
@@ -152,22 +160,27 @@ public class SignServiceImpl implements SignService {
                 .image(profileImageUrl)
                 .role(role)
                 .build();
+        CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, userInfo, "엑세스 토큰을 성공적으로 받았습니다.");
+        return ResponseEntity.status(200).body(res);
+
     }
 
     @Override
-    public User login(UserInfo userInfo) {
+    public ResponseEntity<CustomAPIResponse<?>> login(UserInfo userInfo) {
         Optional<User> foundUser = userRepository.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId());
 
+        String token = "예시토큰";
         //회원가입
         if (foundUser.isEmpty()) {
             User user = userInfo.toEntity();
             userRepository.save(user);
             logger.info("User 회원가입 성공: {}", user.getName());
-            return user;
+            CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(201, token, "카카오톡 회원가입이 성공적으로 완료되었습니다.");
+            return ResponseEntity.status(201).body(res);
         } else { //로그인
             User user = foundUser.get();
             logger.info("User 로그인 성공: {}", user.getName());
-            return user;
-        }
+            CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, token, "카카오톡 로그인이 성공적으로 완료되었습니다.");
+            return ResponseEntity.status(200).body(res);        }
     }
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #56 

### 📄 변경 사항
예외처리 추가 + 코드 수정
- 인가 코드 받기 실패 (401)
- 유효하지 않은 인가코드 (401)
- 접근 토큰 받기 실패 (401)
- 유저 정보 가져오기 실패 (400)
- 회원가입 성공 (201)
- 로그인 성공 (200)

### 🏆 테스트 결과
ex) API의 경우 명세서에 기재된 사항들 Postman으로 테스트한 결과 첨부
- 인가 코드 받기 실패 (401)
- 유효하지 않은 인가코드 (401)
<img width="856" alt="image" src="https://github.com/user-attachments/assets/93f732fa-d679-48a5-a3b6-bf84382d52a2">

- 접근 토큰 받기 실패 (401)

- 유저 정보 가져오기 실패 (400)
- 회원가입 성공 (201)
<img width="863" alt="image" src="https://github.com/user-attachments/assets/8061534b-5ec1-4633-aed1-8239492a3fca">
<img width="610" alt="image" src="https://github.com/user-attachments/assets/7ef986a6-49b0-43bd-964b-76c3761622c2">
-> db에 추가됨

- 로그인 성공 (200)
<img width="850" alt="image" src="https://github.com/user-attachments/assets/cc9ec4ff-c0b6-4df9-a4c0-fa28653ced68">
<img width="712" alt="image" src="https://github.com/user-attachments/assets/74c58a23-bb27-4b39-83df-95479d5eb65e">
-> db에 추가되지 않음

### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
