### PR TITLE
🚨 [Fix] 카카오 소셜로그인 API 구현 - application-secret.properties 설정

### DIFF
--- a/scapture/src/main/java/com/server/scapture/oauth/jwt/JwtUtil.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/jwt/JwtUtil.java
@@ -17,7 +17,7 @@ import java.util.Date;
 public class JwtUtil {
 
     @Value("${jwt.secret}")
-    private String secretKey = "z4FmaD1QnM2Fp1XnT6D2O2h1Q2D3P4R5S6T7U8V9W0X1Y2Z3a4b5c6d7e8f9g0h1";
+    private String secretKey;
 
     private SecretKey getSigningKey() {
         // Base64 URL Decoding을 사용하여 키를 디코딩합니다.

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
@@ -27,7 +27,7 @@ public class SignServiceImpl implements SignService {
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
 
-    @Value("${spring.security.oauth2.client.registration.kakao.client-id}") //-> 후에 오류 수정해야함 jwtUtil 클래스 참고
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String kakaoApiKey;
     @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
     private String kakaoRedirectUri;

--- a/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/SignServiceImpl.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -26,13 +27,17 @@ public class SignServiceImpl implements SignService {
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
 
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}") //-> 후에 오류 수정해야함 jwtUtil 클래스 참고
+    private String kakaoApiKey;
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String reqUrl;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoClientSecret;
     @Override
     public ResponseEntity<CustomAPIResponse<?>> getAccessToken(String code) {
-        String kakaoApiKey = "024871f91fe647ce7262bd022bd1afc2";
-        String kakaoRedirectUri = "http://localhost:3000/oauth/redirected/kakao";
         String accessToken;
-        String reqUrl = "https://kauth.kakao.com/oauth/token";
-        String kakaoClientSecret = "8hIjcRxQfSSvvG8NV1nuksp9k2c9PEUP";
         try {
             URL url = new URL(reqUrl);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();


### PR DESCRIPTION
### 🌈 Issue 번호
- close #54 

### 📄 변경 사항
1. JwtUtill 클래스의 secretKey 부분 숨기기
2. SignServiceImpl의 Kakao관련 키 부분 숨기기

### 🏆 테스트 결과
#### (1)
<img width="225" alt="image" src="https://github.com/user-attachments/assets/22a8e728-1d65-4af1-b5d5-7dcf5df84205">

#### (2)
<img width="624" alt="image" src="https://github.com/user-attachments/assets/524c4538-8809-4292-88bc-2d817714a14e">

#### 결과
<img width="430" alt="스크린샷 2024-07-24 오전 4 04 41" src="https://github.com/user-attachments/assets/8f9c962e-3c52-47a1-aaf6-15c687e0d885">


### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
