### PR TITLE
✨ [Feat] 경기 영상 조회 API 구현

### DIFF
--- a/scapture/src/main/java/com/server/scapture/field/controller/FieldController.java
+++ b/scapture/src/main/java/com/server/scapture/field/controller/FieldController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FieldController {
     private final FieldService fieldService;
     @PostMapping
-    ResponseEntity<CustomAPIResponse<?>> createField(@RequestBody CreateFieldRequestDto createFieldRequestDto) {
+    public ResponseEntity<CustomAPIResponse<?>> createField(@RequestBody CreateFieldRequestDto createFieldRequestDto) {
         return fieldService.createField(createFieldRequestDto);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/schedule/controller/ScheduleController.java
+++ b/scapture/src/main/java/com/server/scapture/schedule/controller/ScheduleController.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class ScheduleController {
     private final ScheduleService scheduleService;
     @PostMapping
-    ResponseEntity<CustomAPIResponse<?>> createSchedule(@RequestBody List<CreateScheduleRequestDto> createScheduleRequestDtos) {
+    public ResponseEntity<CustomAPIResponse<?>> createSchedule(@RequestBody List<CreateScheduleRequestDto> createScheduleRequestDtos) {
         return scheduleService.createSchedule(createScheduleRequestDtos);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/stadium/controller/StadiumController.java
+++ b/scapture/src/main/java/com/server/scapture/stadium/controller/StadiumController.java
@@ -17,23 +17,23 @@ import java.util.List;
 public class StadiumController {
     private final StadiumService stadiumService;
     @PostMapping
-    ResponseEntity<CustomAPIResponse<?>> createStadium(@RequestPart CreateStadiumRequestDto data, @RequestPart List<MultipartFile> images) throws IOException {
+    public ResponseEntity<CustomAPIResponse<?>> createStadium(@RequestPart CreateStadiumRequestDto data, @RequestPart List<MultipartFile> images) throws IOException {
         return stadiumService.createStadium(data, images);
     }
     @GetMapping
-    ResponseEntity<CustomAPIResponse<?>> getStadiumsByCityAndState(@RequestParam("city") String city, @RequestParam("state") String state) {
+    public ResponseEntity<CustomAPIResponse<?>> getStadiumsByCityAndState(@RequestParam("city") String city, @RequestParam("state") String state) {
         return stadiumService.getStadiumByCityAndState(city, state);
     }
     @GetMapping("/search")
-    ResponseEntity<CustomAPIResponse<?>> getStadiumsByKeyword(@RequestParam("keyword") String keyword){
+    public ResponseEntity<CustomAPIResponse<?>> getStadiumsByKeyword(@RequestParam("keyword") String keyword){
         return stadiumService.getStadiumByKeyword(keyword);
     }
     @GetMapping("/{stadiumId}/detail")
-    ResponseEntity<CustomAPIResponse<?>> getStadiumDetail(@PathVariable("stadiumId") Long stadiumId) {
+    public ResponseEntity<CustomAPIResponse<?>> getStadiumDetail(@PathVariable("stadiumId") Long stadiumId) {
         return stadiumService.getStadiumDetail(stadiumId);
     }
     @GetMapping("/{fieldId}")
-    ResponseEntity<CustomAPIResponse<?>> getScheduleByFieldAndDate(@PathVariable("fieldId") Long fieldId, @RequestParam("date") String date) {
+    public ResponseEntity<CustomAPIResponse<?>> getScheduleByFieldAndDate(@PathVariable("fieldId") Long fieldId, @RequestParam("date") String date) {
         return stadiumService.getScheduleByFieldAndDate(fieldId, date);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -20,4 +20,9 @@ public class VideoController {
     public ResponseEntity<CustomAPIResponse<?>> createVideo(@RequestBody VideoCreateRequestDto videoCreateRequestDto) {
         return videoService.createVideo(videoCreateRequestDto);
     }
+
+    @GetMapping("/{scheduleId}")
+    public ResponseEntity<CustomAPIResponse<?>> getVideos(@PathVariable("scheduleId") Long scheduleId) {
+        return null;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -20,9 +20,8 @@ public class VideoController {
     public ResponseEntity<CustomAPIResponse<?>> createVideo(@RequestBody VideoCreateRequestDto videoCreateRequestDto) {
         return videoService.createVideo(videoCreateRequestDto);
     }
-
     @GetMapping("/{scheduleId}")
     public ResponseEntity<CustomAPIResponse<?>> getVideos(@PathVariable("scheduleId") Long scheduleId) {
-        return null;
+        return videoService.getVideos(scheduleId);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/video/dto/GetVideosResponseDto.java
+++ b/scapture/src/main/java/com/server/scapture/video/dto/GetVideosResponseDto.java
@@ -1,0 +1,18 @@
+package com.server.scapture.video.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+@Builder
+public class GetVideosResponseDto {
+    private Long videoId;
+    private String name;
+    private String image;
+    private String stadiumName;
+    private String date;
+    private String hours;
+}

--- a/scapture/src/main/java/com/server/scapture/video/repository/VideoRepository.java
+++ b/scapture/src/main/java/com/server/scapture/video/repository/VideoRepository.java
@@ -6,8 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface VideoRepository extends JpaRepository<Video, Long> {
     @Query("SELECT COUNT(*) FROM Video v WHERE v.schedule = :schedule")
     int countBySchedule(Schedule schedule);
+    List<Video> findBySchedule(Schedule schedule);
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
@@ -10,4 +10,5 @@ import java.util.List;
 
 public interface VideoService {
     ResponseEntity<CustomAPIResponse<?>> createVideo(VideoCreateRequestDto videoCreateRequestDto);
+    ResponseEntity<CustomAPIResponse<?>> getVideos(Long scheduleId);
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
@@ -56,4 +56,9 @@ public class VideoServiceImpl implements VideoService{
                 .status(HttpStatus.CREATED)
                 .body(responseBody);
     }
+
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> getVideos(Long scheduleId) {
+        return null;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
@@ -1,11 +1,16 @@
 package com.server.scapture.video.service;
 
+import com.server.scapture.domain.Field;
 import com.server.scapture.domain.Schedule;
+import com.server.scapture.domain.Stadium;
 import com.server.scapture.domain.Video;
+import com.server.scapture.field.repository.FieldRepository;
 import com.server.scapture.schedule.repository.ScheduleRepository;
 import com.server.scapture.schedule.service.ScheduleService;
+import com.server.scapture.stadium.repository.StadiumRepository;
 import com.server.scapture.util.S3.S3Service;
 import com.server.scapture.util.response.CustomAPIResponse;
+import com.server.scapture.video.dto.GetVideosResponseDto;
 import com.server.scapture.video.dto.VideoCreateDetailDto;
 import com.server.scapture.video.dto.VideoCreateRequestDto;
 import com.server.scapture.video.repository.VideoRepository;
@@ -26,6 +31,8 @@ import java.util.UUID;
 public class VideoServiceImpl implements VideoService{
     private final VideoRepository videoRepository;
     private final ScheduleRepository scheduleRepository;
+    private final FieldRepository fieldRepository;
+    private final StadiumRepository stadiumRepository;
     @Override
     public ResponseEntity<CustomAPIResponse<?>> createVideo(VideoCreateRequestDto videoCreateRequestDto) {
         // 1. 운영 일정 조회
@@ -56,9 +63,48 @@ public class VideoServiceImpl implements VideoService{
                 .status(HttpStatus.CREATED)
                 .body(responseBody);
     }
-
     @Override
     public ResponseEntity<CustomAPIResponse<?>> getVideos(Long scheduleId) {
-        return null;
+        // 1. Schedule 조회
+        Optional<Schedule> foundSchedule = scheduleRepository.findById(scheduleId);
+        // 1-1. 실패
+        if (foundSchedule.isEmpty()) {
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 운영 일정입니다.");
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        // 1-2. 성공
+        Schedule schedule = foundSchedule.get();
+        // 2. 영상 조회
+        List<Video> videoList = videoRepository.findBySchedule(schedule);
+        // 3. 경기장 조회
+        // 3-1. 구장 조회
+        Field field = fieldRepository.findById(schedule.getField().getId()).get();
+        // 3-2. 경기장 조회
+        Stadium stadium = stadiumRepository.findById(field.getStadium().getId()).get();
+        // 4. Response
+        // 4-1. data
+        List<GetVideosResponseDto> data = null;
+        if (!videoList.isEmpty()) {
+            data = new ArrayList<>();
+            for (Video video : videoList) {
+                GetVideosResponseDto responseDto = GetVideosResponseDto.builder()
+                        .videoId(video.getId())
+                        .name(video.getName())
+                        .image(video.getImage())
+                        .stadiumName(stadium.getName())
+                        .date(schedule.convertMonthAndDay())
+                        .hours(schedule.convertHourAndMin())
+                        .build();
+                data.add(responseDto);
+            }
+        }
+        // 4-2. responseBody
+        CustomAPIResponse<List<GetVideosResponseDto>> responseBody = CustomAPIResponse.createSuccess(HttpStatus.OK.value(), data, "경기 영상 조회 완료되었습니다.");
+        // 4-3. ResponseEntity
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(responseBody);
     }
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #71 

### 📄 변경 사항
경기 영상 조회 API 구현
date MM.dd.E Format
hours HH:mm ~ HH:mm Format

### 🏆 테스트 결과
#### 200(성공)
<img width="803" alt="image" src="https://github.com/user-attachments/assets/9574c4e1-7b63-4c69-8e7b-a9c13e976a18">

#### 200(성공)-null
<img width="480" alt="image" src="https://github.com/user-attachments/assets/95a65bd4-e3c0-4cdb-89ee-f0fc650791c4">

#### 404(운영시간 X)
<img width="537" alt="image" src="https://github.com/user-attachments/assets/e16e483f-0737-4a96-a745-6a67c023e63b">

### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
