### PR TITLE
✨ [Feat] 영상 좋아요 추가 / 해제 API 구현

### DIFF
--- a/scapture/src/main/java/com/server/scapture/domain/Video.java
+++ b/scapture/src/main/java/com/server/scapture/domain/Video.java
@@ -25,11 +25,6 @@ public class Video {
     @ColumnDefault("0")
     private int likeCount;          // 좋아요 수
 
-    public void increaseLikeCount() {
-        this.likeCount++;
-    }
-
-    public void decreaseLikeCount() {
-        this.likeCount--;
-    }
+    public void increaseLikeCount() {this.likeCount+=1;}
+    public void decreaseLikeCount() {this.likeCount-=1;}
 }

--- a/scapture/src/main/java/com/server/scapture/domain/Video.java
+++ b/scapture/src/main/java/com/server/scapture/domain/Video.java
@@ -24,4 +24,12 @@ public class Video {
     private String video;           // 영상
     @ColumnDefault("0")
     private int likeCount;          // 좋아요 수
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount--;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -1,9 +1,11 @@
 package com.server.scapture.video.controller;
 
+import com.server.scapture.oauth.jwt.JwtUtil;
 import com.server.scapture.util.response.CustomAPIResponse;
 import com.server.scapture.video.dto.VideoCreateRequestDto;
 import com.server.scapture.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,15 +19,23 @@ import java.util.List;
 public class VideoController {
     private final VideoService videoService;
     @PostMapping
+
     public ResponseEntity<CustomAPIResponse<?>> createVideo(@RequestBody VideoCreateRequestDto videoCreateRequestDto) {
         return videoService.createVideo(videoCreateRequestDto);
     }
+
     @GetMapping("/{scheduleId}")
     public ResponseEntity<CustomAPIResponse<?>> getVideos(@PathVariable("scheduleId") Long scheduleId) {
         return videoService.getVideos(scheduleId);
     }
+
     @GetMapping("/popular")
     public ResponseEntity<CustomAPIResponse<?>> getVideosByLikesCount() {
         return videoService.getVideosByLikeCount();
+    }
+
+    @PostMapping("/{videoId}/likes")
+    public ResponseEntity<CustomAPIResponse<?>> createLike(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
+        return null;
     }
 }

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -38,4 +38,8 @@ public class VideoController {
     public ResponseEntity<CustomAPIResponse<?>> createLike(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
         return videoService.createLike(header, videoId);
     }
+    @DeleteMapping("/{videoId}/likes")
+    public ResponseEntity<CustomAPIResponse<?>> deleteLike(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
+        return videoService.deleteLike(header, videoId);
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -36,6 +36,6 @@ public class VideoController {
 
     @PostMapping("/{videoId}/likes")
     public ResponseEntity<CustomAPIResponse<?>> createLike(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
-        return null;
+        return videoService.createLike(header, videoId);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
@@ -12,4 +12,5 @@ public interface VideoService {
     ResponseEntity<CustomAPIResponse<?>> createVideo(VideoCreateRequestDto videoCreateRequestDto);
     ResponseEntity<CustomAPIResponse<?>> getVideos(Long scheduleId);
     ResponseEntity<CustomAPIResponse<?>> getVideosByLikeCount();
+    ResponseEntity<CustomAPIResponse<?>> createLike(String header, Long videoId);
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
@@ -13,4 +13,5 @@ public interface VideoService {
     ResponseEntity<CustomAPIResponse<?>> getVideos(Long scheduleId);
     ResponseEntity<CustomAPIResponse<?>> getVideosByLikeCount();
     ResponseEntity<CustomAPIResponse<?>> createLike(String header, Long videoId);
+    ResponseEntity<CustomAPIResponse<?>> deleteLike(String header, Long videoId);
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
@@ -166,7 +166,7 @@ public class VideoServiceImpl implements VideoService{
         // 3-1. 중복 데이터 검사
         Optional<VideoLike> foundVideoLike = videoLikeRepository.findByVideoAndUser(video, user);
         if (foundVideoLike.isPresent()) {
-            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.CONFLICT.value(), "이미 존재하는 좋아요입니다.");
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.CONFLICT.value(), "이미 존재하는 영상 좋아요입니다.");
             return ResponseEntity
                     .status(HttpStatus.CONFLICT)
                     .body(responseBody);
@@ -217,7 +217,7 @@ public class VideoServiceImpl implements VideoService{
         // 3-1. 데이터 유무 검사
         Optional<VideoLike> foundVideoLike = videoLikeRepository.findByVideoAndUser(video, user);
         if (foundVideoLike.isEmpty()) {
-            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 좋아요입니다.");
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 영상 좋아요입니다.");
             return ResponseEntity
                     .status(HttpStatus.NOT_FOUND)
                     .body(responseBody);

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
@@ -136,4 +136,8 @@ public class VideoServiceImpl implements VideoService{
                 .status(HttpStatus.OK)
                 .body(responseBody);
     }
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> createLike(String header, Long videoId) {
+        return null;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/videoLike/repository/VideoLikeRepository.java
+++ b/scapture/src/main/java/com/server/scapture/videoLike/repository/VideoLikeRepository.java
@@ -6,7 +6,9 @@ import com.server.scapture.domain.VideoLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface VideoLikeRepository extends JpaRepository<VideoLike, Long> {
-    boolean existsByVideoAndUser(Video video, User user);
+    Optional<VideoLike> findByVideoAndUser(Video video, User user);
 }

--- a/scapture/src/main/java/com/server/scapture/videoLike/repository/VideoLikeRepository.java
+++ b/scapture/src/main/java/com/server/scapture/videoLike/repository/VideoLikeRepository.java
@@ -1,0 +1,12 @@
+package com.server.scapture.videoLike.repository;
+
+import com.server.scapture.domain.User;
+import com.server.scapture.domain.Video;
+import com.server.scapture.domain.VideoLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VideoLikeRepository extends JpaRepository<VideoLike, Long> {
+    boolean existsByVideoAndUser(Video video, User user);
+}


### PR DESCRIPTION
### 🌈 Issue 번호
- close #73 

### 📄 변경 사항
영상 좋아요 추가 / 해제 API 구현

### 🏆 테스트 결과
### 영상 좋아요 추가
#### 201(좋아요 추가)
<img width="434" alt="image" src="https://github.com/user-attachments/assets/2921a1ea-3403-4c22-ad1b-ae7b8c46a8e6">

#### 409(존재하는 좋아요)
<img width="533" alt="image" src="https://github.com/user-attachments/assets/b4e1a5d7-1637-48e5-9203-6ff742631447">

#### 404(영상 ID 조회 불가)
<img width="532" alt="image" src="https://github.com/user-attachments/assets/37a67756-2b16-42a2-8553-479dc26f373f">

### 영상 좋아요 해제
#### 404(존재하지 않는 좋아요)
<img width="454" alt="image" src="https://github.com/user-attachments/assets/7532e125-3f53-4346-be35-121bfa5ff6f7">

#### 404(존재하지 않는 영상)
<img width="487" alt="image" src="https://github.com/user-attachments/assets/24e61411-ebf6-48ec-afb1-c018e7e6ab2e">

### Reviewer 요구 사항
- <영상 좋아요 추가(404)-사용자 ID 조회 불가> Test 불가
- <영상 좋아요 해제(404)-사용자 ID 조회 불가> Test 불가
