### PR TITLE
✨ [Feat] 영상 저장 / 해제 API 구현

### DIFF
--- a/scapture/src/main/java/com/server/scapture/store/repository/StoreRepository.java
+++ b/scapture/src/main/java/com/server/scapture/store/repository/StoreRepository.java
@@ -1,0 +1,14 @@
+package com.server.scapture.store.repository;
+
+import com.server.scapture.domain.Store;
+import com.server.scapture.domain.User;
+import com.server.scapture.domain.Video;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, Long> {
+    Optional<Store> findByVideoAndUser(Video video, User user);
+}

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -43,9 +43,13 @@ public class VideoController {
     public ResponseEntity<CustomAPIResponse<?>> deleteLike(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
         return videoService.deleteLike(header, videoId);
     }
-
     @PostMapping("/{videoId}/store")
     public ResponseEntity<CustomAPIResponse<?>> createStore(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
         return videoService.createStore(header, videoId);
+    }
+
+    @DeleteMapping("/{videoId}/store")
+    public ResponseEntity<CustomAPIResponse<?>> deleteStore(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
+        return null;
     }
 }

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -46,6 +46,6 @@ public class VideoController {
 
     @PostMapping("/{videoId}/store")
     public ResponseEntity<CustomAPIResponse<?>> createStore(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
-        return null;
+        return videoService.createStore(header, videoId);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -7,6 +7,7 @@ import com.server.scapture.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -41,5 +42,10 @@ public class VideoController {
     @DeleteMapping("/{videoId}/likes")
     public ResponseEntity<CustomAPIResponse<?>> deleteLike(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
         return videoService.deleteLike(header, videoId);
+    }
+
+    @PostMapping("/{videoId}/store")
+    public ResponseEntity<CustomAPIResponse<?>> createStore(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
+        return null;
     }
 }

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -50,6 +50,6 @@ public class VideoController {
 
     @DeleteMapping("/{videoId}/store")
     public ResponseEntity<CustomAPIResponse<?>> deleteStore(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
-        return null;
+        return videoService.deleteStore(header, videoId);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
@@ -14,4 +14,5 @@ public interface VideoService {
     ResponseEntity<CustomAPIResponse<?>> getVideosByLikeCount();
     ResponseEntity<CustomAPIResponse<?>> createLike(String header, Long videoId);
     ResponseEntity<CustomAPIResponse<?>> deleteLike(String header, Long videoId);
+    ResponseEntity<CustomAPIResponse<?>> createStore(String header, Long videoId);
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
@@ -15,4 +15,5 @@ public interface VideoService {
     ResponseEntity<CustomAPIResponse<?>> createLike(String header, Long videoId);
     ResponseEntity<CustomAPIResponse<?>> deleteLike(String header, Long videoId);
     ResponseEntity<CustomAPIResponse<?>> createStore(String header, Long videoId);
+    ResponseEntity<CustomAPIResponse<?>> deleteStore(String header, Long videoId);
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
@@ -188,7 +188,6 @@ public class VideoServiceImpl implements VideoService{
                 .status(HttpStatus.CREATED)
                 .body(responseBody);
     }
-
     @Override
     public ResponseEntity<CustomAPIResponse<?>> deleteLike(String header, Long videoId) {
         // 1. User 조회
@@ -235,5 +234,9 @@ public class VideoServiceImpl implements VideoService{
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .body(responseBody);
+    }
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> createStore(String header, Long videoId) {
+        return null;
     }
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
@@ -284,4 +284,8 @@ public class VideoServiceImpl implements VideoService{
                 .status(HttpStatus.CREATED)
                 .body(responseBody);
     }
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> deleteStore(String header, Long videoId) {
+        return null;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
@@ -262,7 +262,7 @@ public class VideoServiceImpl implements VideoService{
         }
         // 2-2. 성공
         Video video = foundVideo.get();
-        // 3. Store 객체 생성
+        // 3. Store 생성
         // 3-1. 중복 검사
         Optional<Store> foundStore = storeRepository.findByVideoAndUser(video, user);
         if (foundStore.isPresent()) {
@@ -271,7 +271,7 @@ public class VideoServiceImpl implements VideoService{
                     .status(HttpStatus.CONFLICT)
                     .body(responseBody);
         }
-        // 3-2. Store 객체 생성
+        // 3-2. Store 생성
         Store store = Store.builder()
                 .user(user)
                 .video(video)
@@ -286,6 +286,45 @@ public class VideoServiceImpl implements VideoService{
     }
     @Override
     public ResponseEntity<CustomAPIResponse<?>> deleteStore(String header, Long videoId) {
-        return null;
+        // 1. 사용자 조회
+        Optional<User> foundUser = jwtUtil.findUserByJwtToken(header);
+        // 1-1. 실패
+        if (foundUser.isEmpty()) {
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 사용자입니다.");
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        // 1-2. 성공
+        User user = foundUser.get();
+        // 2. 영상 조회
+        Optional<Video> foundVideo = videoRepository.findById(videoId);
+        // 2-1. 실패
+        if (foundVideo.isEmpty()) {
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 영상입니다.");
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        // 2-2. 성공
+        Video video = foundVideo.get();
+        // 3. Store 객체 생성
+        // 3-1. 중복 검사
+        Optional<Store> foundStore = storeRepository.findByVideoAndUser(video, user);
+        if (foundStore.isEmpty()) {
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 저장입니다.");
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        // 3-2. Store 가져오기
+        Store store = foundStore.get();
+        // 3-3. Store 삭제
+        storeRepository.delete(store);
+        // 4. Response
+        CustomAPIResponse<Object> responseBody = CustomAPIResponse.createSuccessWithoutData(HttpStatus.NO_CONTENT.value(), "저장 삭제 완료되었습니다.");
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .body(responseBody);
     }
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #74 

### 📄 변경 사항
영상 저장 / 해제 API 구현

### 🏆 테스트 결과
### 영상 저장
#### 201(영상 저장)
<img width="523" alt="image" src="https://github.com/user-attachments/assets/865e8be4-e6f6-4ec5-949c-1232bf4eedcb">

#### 409(존재하는 저장)
<img width="537" alt="image" src="https://github.com/user-attachments/assets/1b4c5a99-958c-43d0-b639-60beb68d15c7">

#### 404(존재하지 않는 영상)
<img width="538" alt="image" src="https://github.com/user-attachments/assets/e7dd118e-18fd-4522-8c38-c4a2f9474fe0">

### 영상 저장 해제
#### 404(존재하지 않는 저장)
<img width="535" alt="image" src="https://github.com/user-attachments/assets/4a2b62d9-34c3-4e17-9a21-a9d8e5678017">

#### 404(존재하지 않는 영상)
<img width="447" alt="image" src="https://github.com/user-attachments/assets/df92ea9e-b70f-40ae-a936-512d31f7e358">

### Reviewer 요구 사항
- <영상 좋아요 추가(404)-사용자 ID 조회 불가> Test 불가
- <영상 좋아요 해제(404)-사용자 ID 조회 불가> Test 불가
