### PR TITLE
✨ [Feat] 영상 다운로드 권한 부여 API 구현

### DIFF
--- a/scapture/src/main/java/com/server/scapture/download/repository/DownloadRepository.java
+++ b/scapture/src/main/java/com/server/scapture/download/repository/DownloadRepository.java
@@ -1,0 +1,9 @@
+package com.server.scapture.download.repository;
+
+import com.server.scapture.domain.Download;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DownloadRepository extends JpaRepository<Download, Long> {
+}

--- a/scapture/src/main/java/com/server/scapture/download/repository/DownloadRepository.java
+++ b/scapture/src/main/java/com/server/scapture/download/repository/DownloadRepository.java
@@ -1,9 +1,14 @@
 package com.server.scapture.download.repository;
 
 import com.server.scapture.domain.Download;
+import com.server.scapture.domain.User;
+import com.server.scapture.domain.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface DownloadRepository extends JpaRepository<Download, Long> {
+    Optional<Download> findByVideoAndUser(Video video, User user);
 }

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -58,6 +58,6 @@ public class VideoController {
 
     @PostMapping("/{videoId}/download")
     public ResponseEntity<CustomAPIResponse<?>> createDownload(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
-        return null;
+        return videoService.createDownload(header, videoId);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
+++ b/scapture/src/main/java/com/server/scapture/video/controller/VideoController.java
@@ -55,4 +55,9 @@ public class VideoController {
     public ResponseEntity<CustomAPIResponse<?>> deleteStore(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
         return videoService.deleteStore(header, videoId);
     }
+
+    @PostMapping("/{videoId}/download")
+    public ResponseEntity<CustomAPIResponse<?>> createDownload(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("videoId") Long videoId) {
+        return null;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoService.java
@@ -18,4 +18,5 @@ public interface VideoService {
     ResponseEntity<CustomAPIResponse<?>> deleteLike(String header, Long videoId);
     ResponseEntity<CustomAPIResponse<?>> createStore(String header, Long videoId);
     ResponseEntity<CustomAPIResponse<?>> deleteStore(String header, Long videoId);
-}
+    ResponseEntity<CustomAPIResponse<?>> createDownload(String header, Long videoId);
+ }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
@@ -436,4 +436,8 @@ public class VideoServiceImpl implements VideoService{
                 .status(HttpStatus.NO_CONTENT)
                 .body(responseBody);
     }
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> createDownload(String header, Long videoId) {
+        return null;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/video/service/VideoServiceImpl.java
@@ -1,6 +1,7 @@
 package com.server.scapture.video.service;
 
 import com.server.scapture.domain.*;
+import com.server.scapture.download.repository.DownloadRepository;
 import com.server.scapture.field.repository.FieldRepository;
 import com.server.scapture.oauth.jwt.JwtUtil;
 import com.server.scapture.schedule.repository.ScheduleRepository;
@@ -29,6 +30,7 @@ public class VideoServiceImpl implements VideoService{
     private final StadiumRepository stadiumRepository;
     private final VideoLikeRepository videoLikeRepository;
     private final StoreRepository storeRepository;
+    private final DownloadRepository downloadRepository;
     private final JwtUtil jwtUtil;
     @Override
     public ResponseEntity<CustomAPIResponse<?>> createVideo(VideoCreateRequestDto videoCreateRequestDto) {
@@ -438,6 +440,47 @@ public class VideoServiceImpl implements VideoService{
     }
     @Override
     public ResponseEntity<CustomAPIResponse<?>> createDownload(String header, Long videoId) {
-        return null;
+        // 1. 영상 조회
+        Optional<Video> foundVideo = videoRepository.findById(videoId);
+        // 1-1. 실패
+        if (foundVideo.isEmpty()) {
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 영상입니다.");
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        // 1-2. 성공
+        Video video = foundVideo.get();
+        // 1. 사용자 조회
+        Optional<User> foundUser = jwtUtil.findUserByJwtToken(header);
+        // 1-1. 실패
+        if (foundUser.isEmpty()) {
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 사용자입니다.");
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        // 1-2. 성공
+        User user = foundUser.get();
+        // 3. Download 생성
+        // 3-1. 중복 검사
+        Optional<Download> foundDownload = downloadRepository.findByVideoAndUser(video, user);
+        if (foundDownload.isPresent()) {
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.CONFLICT.value(), "이미 존재하는 권한입니다.");
+            return ResponseEntity
+                    .status(HttpStatus.CONFLICT)
+                    .body(responseBody);
+        }
+        // 3-2. Download 저장
+        Download download = Download.builder()
+                .video(video)
+                .user(user)
+                .build();
+        downloadRepository.save(download);
+        // 4. Response
+        CustomAPIResponse<Object> responseBody = CustomAPIResponse.createSuccessWithoutData(HttpStatus.CREATED.value(), "영상 다운로드 권한 부여 완료되었습니다.");
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(responseBody);
     }
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #77 

### 📄 변경 사항
영상 다운로드 권한 부여 API 구현

### 🏆 테스트 결과
#### 201(성공)
<img width="534" alt="image" src="https://github.com/user-attachments/assets/d5c98e0b-a607-4e9b-9746-af8e23f44d30">

#### 409(이미 존재하는 권한)
<img width="523" alt="image" src="https://github.com/user-attachments/assets/3d8c3580-e4b8-4f26-93f8-9aa55576cda7">

#### 404(존재하지 않는 영상)
<img width="523" alt="image" src="https://github.com/user-attachments/assets/3d8c3580-e4b8-4f26-93f8-9aa55576cda7">


### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
