### PR TITLE
✨ [Feat] 버내너 잔액 조회 API 구현

### DIFF
--- a/scapture/src/main/java/com/server/scapture/domain/Subscribe.java
+++ b/scapture/src/main/java/com/server/scapture/domain/Subscribe.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 @Entity
 @Getter
@@ -25,4 +26,5 @@ public class Subscribe {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
         return endDate.format(formatter);
     }
+
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/jwt/JwtUtil.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/jwt/JwtUtil.java
@@ -21,8 +21,8 @@ import java.util.Optional;
 @Component
 public class JwtUtil {
 
-    @Value("${jwt.secret}")
-    private String secretKey;
+    private String secretKey = "z4FmaD1QnM2Fp1XnT6D2O2h1Q2D3P4R5S6T7U8V9W0X1Y2Z3a4b5c6d7e8f9g0h1";
+
 
     @Autowired
     private UserRepository userRepository;

--- a/scapture/src/main/java/com/server/scapture/oauth/jwt/JwtUtil.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/jwt/JwtUtil.java
@@ -21,11 +21,41 @@ import java.util.Optional;
 @Component
 public class JwtUtil {
 
-    private String secretKey = "z4FmaD1QnM2Fp1XnT6D2O2h1Q2D3P4R5S6T7U8V9W0X1Y2Z3a4b5c6d7e8f9g0h1";
-
+    @Value("${jwt.secret}")private String secretKey;
 
     @Autowired
     private UserRepository userRepository;
+
+    // 토큰으로 유저 찾기
+    public Optional<User> findUserByJwtToken(String authorizationHeader) {
+        String token = getTokenFromHeader(authorizationHeader);
+        if (token == null) {
+            log.warn("헤더에 JWT 토큰이 없음");
+            return Optional.empty();
+        }
+
+        Claims claims = getClaimsFromToken(token);
+        if (claims == null) {
+            log.warn("유효하지 않은 JWT 토큰");
+            return Optional.empty();
+        }
+
+        String provider = getProviderFromToken(token);
+        String providerId = getProviderIdFromToken(token);
+
+        if (provider == null || providerId == null) {
+            log.warn("Provider 또는 providerId 가 JWT에 들어있지 않습니다.");
+            return Optional.empty();
+        }
+
+        Optional<User> foundUser = userRepository.findByProviderAndProviderId(provider, providerId);
+        if (foundUser.isEmpty()) {
+            log.warn("해당 provider, providerId를 가진 회원이 존재하지 않습니다.");
+            return Optional.empty();
+        }
+
+        return foundUser;
+    }
 
     private SecretKey getSigningKey() {
         log.info("secretKey : {}", secretKey);
@@ -97,35 +127,5 @@ public class JwtUtil {
             return expirationDate.before(new Date());
         }
         return null;
-    }
-
-    public Optional<User> findUserByJwtToken(String authorizationHeader) {
-        String token = getTokenFromHeader(authorizationHeader);
-        if (token == null) {
-            log.warn("헤더에 JWT 토큰이 없음");
-            return Optional.empty();
-        }
-
-        Claims claims = getClaimsFromToken(token);
-        if (claims == null) {
-            log.warn("유효하지 않은 JWT 토큰");
-            return Optional.empty();
-        }
-
-        String provider = getProviderFromToken(token);
-        String providerId = getProviderIdFromToken(token);
-
-        if (provider == null || providerId == null) {
-            log.warn("Provider 또는 providerId 가 JWT에 들어있지 않습니다.");
-            return Optional.empty();
-        }
-
-        Optional<User> foundUser = userRepository.findByProviderAndProviderId(provider, providerId);
-        if (foundUser.isEmpty()) {
-            log.warn("해당 provider, providerId를 가진 회원이 존재하지 않습니다.");
-            return Optional.empty();
-        }
-
-        return foundUser;
     }
 }

--- a/scapture/src/main/java/com/server/scapture/subscribe/repository/SubscribeRepository.java
+++ b/scapture/src/main/java/com/server/scapture/subscribe/repository/SubscribeRepository.java
@@ -1,11 +1,13 @@
 package com.server.scapture.subscribe.repository;
 
+import com.server.scapture.domain.Subscribe;
 import com.server.scapture.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface SubscribeRepository {
-    Optional<User> findByUserId(Long id);
+public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+    Optional<Subscribe> findByUserId(Long id);
 }

--- a/scapture/src/main/java/com/server/scapture/subscribe/repository/SubscribeRepository.java
+++ b/scapture/src/main/java/com/server/scapture/subscribe/repository/SubscribeRepository.java
@@ -1,0 +1,11 @@
+package com.server.scapture.subscribe.repository;
+
+import com.server.scapture.domain.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SubscribeRepository {
+    Optional<User> findByUserId(Long id);
+}

--- a/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
+++ b/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
@@ -5,7 +5,6 @@ import com.server.scapture.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,13 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("api/user")
 public class UserController {
 
-    private UserService userService;
+    private final UserService userService;
 
     // 버내너 잔액 조회
-    @GetMapping("/banana")
+    @GetMapping("/bananas")
     public ResponseEntity<CustomAPIResponse<?>> searchBananas(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader){
         return userService.getBananaBalance(authorizationHeader);
-
     }
 }

--- a/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
+++ b/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
@@ -1,7 +1,13 @@
 package com.server.scapture.user.controller;
 
+import com.server.scapture.user.service.UserService;
+import com.server.scapture.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("api/user")
 public class UserController {
+
+    private UserService userService;
+
+    // 버내너 잔액 조회
+    @GetMapping("/banana")
+    public ResponseEntity<CustomAPIResponse<?>> searchBananas(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader){
+        return userService.getBananaBalance(authorizationHeader);
+
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
+++ b/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
@@ -1,0 +1,12 @@
+package com.server.scapture.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/user")
+public class UserController {
+}

--- a/scapture/src/main/java/com/server/scapture/user/dto/BananaBalanceResponseDto.java
+++ b/scapture/src/main/java/com/server/scapture/user/dto/BananaBalanceResponseDto.java
@@ -2,12 +2,13 @@ package com.server.scapture.user.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.Setter;
 
-@Setter
+@Getter @Setter
 @AllArgsConstructor
 @Builder
-public class BananaGetDetailDto {
+public class BananaBalanceResponseDto {
     private int balance;
     private boolean isSubscribed;
 }

--- a/scapture/src/main/java/com/server/scapture/user/dto/BananaGetDetailDto.java
+++ b/scapture/src/main/java/com/server/scapture/user/dto/BananaGetDetailDto.java
@@ -1,0 +1,13 @@
+package com.server.scapture.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Setter;
+
+@Setter
+@AllArgsConstructor
+@Builder
+public class BananaGetDetailDto {
+    private int balance;
+    private boolean isSubscribed;
+}

--- a/scapture/src/main/java/com/server/scapture/user/repository/UserRepository.java
+++ b/scapture/src/main/java/com/server/scapture/user/repository/UserRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    User findByProviderId(String providerId);
 
+    User findByProviderId(String providerId);
     Optional<User> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/scapture/src/main/java/com/server/scapture/user/service/UserService.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserService.java
@@ -1,4 +1,9 @@
 package com.server.scapture.user.service;
 
+import com.server.scapture.util.response.CustomAPIResponse;
+import org.springframework.http.ResponseEntity;
+
 public interface UserService {
+    // 버내너 잔액 조회
+    ResponseEntity<CustomAPIResponse<?>> getBananaBalance(String authorizationHeader);
 }

--- a/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
@@ -28,7 +28,7 @@ public class UserServiceImpl implements UserService{
 
         // 토큰에 해당하는 회원이 없을 시
         if (foundUser.isEmpty()) {
-            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401, "유효하지 않은 토큰이거나, 토큰으로 유저 정보를 조회하는데 실패하였습니다.");
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401, "유효하지 않은 토큰이거나, 해당 ID에 해당하는 회원이 없습니다.");
             return ResponseEntity.status(401).body(res);
         }
         User user = foundUser.get();

--- a/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
@@ -1,16 +1,41 @@
 package com.server.scapture.user.service;
 
+import com.server.scapture.domain.Subscribe;
+import com.server.scapture.domain.User;
+import com.server.scapture.oauth.jwt.JwtUtil;
+import com.server.scapture.subscribe.repository.SubscribeRepository;
+import com.server.scapture.user.dto.BananaGetDetailDto;
 import com.server.scapture.user.repository.UserRepository;
-
+import com.server.scapture.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
-
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService{
     private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final SubscribeRepository subscribeRepository;
+
+    // 버내너 잔액 조회
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> getBananaBalance(String authorizationHeader) {
+        Optional<User> foundUserByToken = jwtUtil.findUserByJwtToken(authorizationHeader);
+
+        // 토큰에 해당하는 회원이 없을 시
+        if (foundUserByToken.isEmpty()) {
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401, "유효하지 않은 토큰이거나, 토큰으로 유저 정보를 조회하는데 실패하였습니다.");
+            return ResponseEntity.status(401).body(res);
+        }
+
+        User user = foundUserByToken.get();
 
 
+
+        return null;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
@@ -4,7 +4,7 @@ import com.server.scapture.domain.Subscribe;
 import com.server.scapture.domain.User;
 import com.server.scapture.oauth.jwt.JwtUtil;
 import com.server.scapture.subscribe.repository.SubscribeRepository;
-import com.server.scapture.user.dto.BananaGetDetailDto;
+import com.server.scapture.user.dto.BananaBalanceResponseDto;
 import com.server.scapture.user.repository.UserRepository;
 import com.server.scapture.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,18 +24,35 @@ public class UserServiceImpl implements UserService{
     // 버내너 잔액 조회
     @Override
     public ResponseEntity<CustomAPIResponse<?>> getBananaBalance(String authorizationHeader) {
-        Optional<User> foundUserByToken = jwtUtil.findUserByJwtToken(authorizationHeader);
+        Optional<User> foundUser = jwtUtil.findUserByJwtToken(authorizationHeader);
 
         // 토큰에 해당하는 회원이 없을 시
-        if (foundUserByToken.isEmpty()) {
+        if (foundUser.isEmpty()) {
             CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401, "유효하지 않은 토큰이거나, 토큰으로 유저 정보를 조회하는데 실패하였습니다.");
             return ResponseEntity.status(401).body(res);
         }
+        User user = foundUser.get();
 
-        User user = foundUserByToken.get();
+        Optional<Subscribe> foundSubscribe = subscribeRepository.findByUserId(user.getId());
 
+        // 해당 회원이 구독중이 아닌 경우
+        if (foundSubscribe.isEmpty()) {
+            BananaBalanceResponseDto bananaBalanceResponseDto = BananaBalanceResponseDto.builder()
+                    .balance(user.getBanana())
+                    .isSubscribed(false)
+                    .build();
+            // 조회 성공, 구독중 X (200)
+            CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, bananaBalanceResponseDto, "버내너 잔액 조회 완료되었습니다. 해당 회원은 구독중이 아닙니다.");
+            return ResponseEntity.status(200).body(res);
+        }
 
-
-        return null;
+        // 해당 회원이 구독중인 경우
+        BananaBalanceResponseDto bananaBalanceResponseDto = BananaBalanceResponseDto.builder()
+                .balance(user.getBanana())
+                .isSubscribed(true)
+                .build();
+        // 조회 성공, 구독중 O (200)
+        CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, bananaBalanceResponseDto, "버내너 잔액 조회 완료되었습니다. 해당 회원은 구독중입니다.");
+        return ResponseEntity.status(200).body(res);
     }
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #91 

### 📄 변경 사항
jwt 토큰을 이용한 회원의 버내너 잔액 조회 기능 구현

### 🏆 테스트 결과
1. 잔액조회 성공(200)
- 구독 중 아닌 경우
<img width="851" alt="image" src="https://github.com/user-attachments/assets/6419739c-ff60-404d-b2e1-ad17879c122b">
<br><br>

- 구독 중인 경우

<img width="857" alt="image" src="https://github.com/user-attachments/assets/dcb35865-31fe-4790-91d3-8314177e3d24">

3. 잔액조회 실패(404)
<img width="845" alt="image" src="https://github.com/user-attachments/assets/8d218d9e-31e1-46d3-8eeb-44f6fa24e851">

### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
