### PR TITLE
✨ [Feat] 구장 예약 일정 조회 API 구현

### DIFF
--- a/scapture/src/main/java/com/server/scapture/reservation/controller/ReservationController.java
+++ b/scapture/src/main/java/com/server/scapture/reservation/controller/ReservationController.java
@@ -16,4 +16,9 @@ public class ReservationController {
     public ResponseEntity<CustomAPIResponse<?>> createReservation(@RequestHeader(HttpHeaders.AUTHORIZATION) String header,  @PathVariable("scheduleId") Long scheduleId) {
         return reservationService.createReservation(header, scheduleId);
     }
+
+    @GetMapping("/{stadiumId}")
+    public ResponseEntity<CustomAPIResponse<?>> getReservation(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("stadiumId") Long stadiumId, @RequestParam("date") String date) {
+        return null;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/reservation/controller/ReservationController.java
+++ b/scapture/src/main/java/com/server/scapture/reservation/controller/ReservationController.java
@@ -18,7 +18,7 @@ public class ReservationController {
     }
 
     @GetMapping("/{stadiumId}")
-    public ResponseEntity<CustomAPIResponse<?>> getReservation(@RequestHeader(HttpHeaders.AUTHORIZATION) String header, @PathVariable("stadiumId") Long stadiumId, @RequestParam("date") String date) {
-        return null;
+    public ResponseEntity<CustomAPIResponse<?>> getReservation(@PathVariable("stadiumId") Long stadiumId, @RequestParam("date") String date) {
+        return reservationService.getReservation(stadiumId, date);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/reservation/dto/GetReservationResponseDto.java
+++ b/scapture/src/main/java/com/server/scapture/reservation/dto/GetReservationResponseDto.java
@@ -14,6 +14,6 @@ public class GetReservationResponseDto {
     private String type;
     private String hours;
     private String date;
-    private boolean isReserved;
+    private Boolean isReserved;
     private int price;
 }

--- a/scapture/src/main/java/com/server/scapture/reservation/dto/GetReservationResponseDto.java
+++ b/scapture/src/main/java/com/server/scapture/reservation/dto/GetReservationResponseDto.java
@@ -1,0 +1,19 @@
+package com.server.scapture.reservation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@AllArgsConstructor
+@Builder
+public class GetReservationResponseDto {
+    private Long scheduleId;
+    private String name;
+    private String type;
+    private String hours;
+    private String date;
+    private boolean isReserved;
+    private int price;
+}

--- a/scapture/src/main/java/com/server/scapture/reservation/dto/SortReservationDto.java
+++ b/scapture/src/main/java/com/server/scapture/reservation/dto/SortReservationDto.java
@@ -1,0 +1,23 @@
+package com.server.scapture.reservation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter
+@AllArgsConstructor
+@Builder
+public class SortReservationDto {
+    private int index;
+    private LocalDateTime startDate;
+    private Long scheduleId;
+    private String name;
+    private String type;
+    private String hours;
+    private String date;
+    private boolean isReserved;
+    private int price;
+}

--- a/scapture/src/main/java/com/server/scapture/reservation/service/ReservationService.java
+++ b/scapture/src/main/java/com/server/scapture/reservation/service/ReservationService.java
@@ -5,5 +5,5 @@ import org.springframework.http.ResponseEntity;
 
 public interface ReservationService {
     ResponseEntity<CustomAPIResponse<?>> createReservation(String header, Long scheduleId);
-    ResponseEntity<CustomAPIResponse<?>> getReservation(String header, Long scheduleId, String date);
+    ResponseEntity<CustomAPIResponse<?>> getReservation(Long stadiumId, String date);
 }

--- a/scapture/src/main/java/com/server/scapture/reservation/service/ReservationService.java
+++ b/scapture/src/main/java/com/server/scapture/reservation/service/ReservationService.java
@@ -5,4 +5,5 @@ import org.springframework.http.ResponseEntity;
 
 public interface ReservationService {
     ResponseEntity<CustomAPIResponse<?>> createReservation(String header, Long scheduleId);
+    ResponseEntity<CustomAPIResponse<?>> getReservation(String header, Long scheduleId, String date);
 }

--- a/scapture/src/main/java/com/server/scapture/reservation/service/ReservationServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/reservation/service/ReservationServiceImpl.java
@@ -8,7 +8,6 @@ import com.server.scapture.reservation.repository.ReservationRepository;
 import com.server.scapture.schedule.repository.ScheduleRepository;
 import com.server.scapture.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -17,7 +16,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class ReservationServideImpl implements ReservationService{
+public class ReservationServiceImpl implements ReservationService{
     private final ReservationRepository reservationRepository;
     private final ScheduleRepository scheduleRepository;
     private final JwtUtil jwtUtil;
@@ -64,5 +63,9 @@ public class ReservationServideImpl implements ReservationService{
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(responseBody);
+    }
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> getReservation(String header, Long scheduleId, String date) {
+        return null;
     }
 }

--- a/scapture/src/main/java/com/server/scapture/reservation/service/ReservationServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/reservation/service/ReservationServiceImpl.java
@@ -1,17 +1,25 @@
 package com.server.scapture.reservation.service;
 
-import com.server.scapture.domain.Reservation;
-import com.server.scapture.domain.Schedule;
-import com.server.scapture.domain.User;
+import com.server.scapture.domain.*;
+import com.server.scapture.field.repository.FieldRepository;
 import com.server.scapture.oauth.jwt.JwtUtil;
+import com.server.scapture.reservation.dto.GetReservationResponseDto;
+import com.server.scapture.reservation.dto.SortReservationDto;
 import com.server.scapture.reservation.repository.ReservationRepository;
 import com.server.scapture.schedule.repository.ScheduleRepository;
+import com.server.scapture.stadium.repository.StadiumRepository;
 import com.server.scapture.util.response.CustomAPIResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -19,6 +27,8 @@ import java.util.Optional;
 public class ReservationServiceImpl implements ReservationService{
     private final ReservationRepository reservationRepository;
     private final ScheduleRepository scheduleRepository;
+    private final FieldRepository fieldRepository;
+    private final StadiumRepository stadiumRepository;
     private final JwtUtil jwtUtil;
     @Override
     public ResponseEntity<CustomAPIResponse<?>> createReservation(String header, Long scheduleId) {
@@ -65,7 +75,94 @@ public class ReservationServiceImpl implements ReservationService{
                 .body(responseBody);
     }
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> getReservation(String header, Long scheduleId, String date) {
-        return null;
+    public ResponseEntity<CustomAPIResponse<?>> getReservation(Long stadiumId, String date) {
+        // 1. 경기장 조회
+        Optional<Stadium> foundStadium = stadiumRepository.findById(stadiumId);
+        // 1-1. 실패
+        if (foundStadium.isEmpty()) {
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "존재하지 않는 경기장입니다.");
+            return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(responseBody);
+        }
+        // 1-2. 성공
+        Stadium stadium = foundStadium.get();
+        // 2. 날짜 검증
+        // 2-1. 요청 값 LocalDate로 변환
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDate parsedDate = LocalDate.parse(date, formatter);
+        // 2-2. 기한(1주일) 내 날짜 확인
+        LocalDate startDate =  LocalDate.now().minusDays(8);
+        LocalDate endDate = LocalDate.now().plusDays(1);
+        // 2-3. 검증 실패(1주일 전이 아닌 다른 요청 날짜)
+        if (!(parsedDate.isAfter(startDate) && parsedDate.isBefore(endDate))) {
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createFailWithoutData(HttpStatus.FORBIDDEN.value(), "허용되지 않는 날짜입니다.");
+            return ResponseEntity
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(responseBody);
+        }
+        // 3. 경기장 예약 정보 조회(전체)
+        // 3-1. responseDto
+        List<SortReservationDto> sortedList = new ArrayList<>();
+        // 3-2. 구장 조회
+        List<Field> fieldList = fieldRepository.findByStadium(stadium);
+        // 3-3. 운영 일정 조회
+        int index = 0;
+        for (Field field : fieldList) {
+            List<Schedule> scheduleList = scheduleRepository.findScheduleByFieldBetweenMonthAndDay(field, parsedDate);
+            for (Schedule schedule : scheduleList) {
+                SortReservationDto dto = SortReservationDto.builder()
+                        .index(index)
+                        .startDate(schedule.getStartDate())
+                        .scheduleId(schedule.getId())
+                        .name(field.getName())
+                        .type(field.getType())
+                        .hours(schedule.convertHourAndMin())
+                        .date(schedule.convertAll())
+                        .isReserved(schedule.getIsReserved())
+                        .price(schedule.getPrice())
+                        .build();
+                sortedList.add(dto);
+            }
+            index++;
+        }
+        // 4. 시간순 정렬
+        sortedList.sort(new Comparator<SortReservationDto>() {
+            @Override
+            public int compare(SortReservationDto o1, SortReservationDto o2) {
+                if(o1.getStartDate().equals(o2.getStartDate())) return o1.getIndex() - o2.getIndex();
+                return o1.getStartDate().compareTo(o2.getStartDate());
+            }
+        });
+        // 5. 같은 시간끼리 리스트 만들기
+        // 5-1. data
+        List<List<GetReservationResponseDto>> data = new ArrayList<>();
+        // 5-2. 같은 시간 리스트업
+        List<GetReservationResponseDto> responseDtoList = new ArrayList<>();
+        LocalDateTime targetTime = sortedList.get(0).getStartDate();
+        for (SortReservationDto sortReservationDto : sortedList) {
+            // 5-2-1. responseDto
+            GetReservationResponseDto responseDto = GetReservationResponseDto.builder()
+                    .scheduleId(sortReservationDto.getScheduleId())
+                    .name(sortReservationDto.getName())
+                    .type(sortReservationDto.getType())
+                    .hours(sortReservationDto.getHours())
+                    .date(sortReservationDto.getDate())
+                    .isReserved(sortReservationDto.isReserved())
+                    .price(sortReservationDto.getPrice())
+                    .build();
+            // 5-2-1. 같은 시간 리스트업
+            if (!targetTime.equals(sortReservationDto.getStartDate())) {
+                data.add(responseDtoList);
+                responseDtoList = new ArrayList<>();
+                targetTime = sortReservationDto.getStartDate();
+            }
+            responseDtoList.add(responseDto);
+        }
+        // 6. Response
+        CustomAPIResponse<List<List<GetReservationResponseDto>>> responseBody = CustomAPIResponse.createSuccess(HttpStatus.OK.value(), data, "예약 조회 완료되었습니다.");
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(responseBody);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/reservation/service/ReservationServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/reservation/service/ReservationServiceImpl.java
@@ -126,7 +126,14 @@ public class ReservationServiceImpl implements ReservationService{
             }
             index++;
         }
-        // 4. 시간순 정렬
+        // 4. data 0
+        if (sortedList.isEmpty()) {
+            CustomAPIResponse<Object> responseBody = CustomAPIResponse.createSuccessWithoutData(HttpStatus.OK.value(), "예약 조회 완료되었습니다.");
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(responseBody);
+        }
+        // 5. 시간순 정렬
         sortedList.sort(new Comparator<SortReservationDto>() {
             @Override
             public int compare(SortReservationDto o1, SortReservationDto o2) {
@@ -134,14 +141,14 @@ public class ReservationServiceImpl implements ReservationService{
                 return o1.getStartDate().compareTo(o2.getStartDate());
             }
         });
-        // 5. 같은 시간끼리 리스트 만들기
-        // 5-1. data
+        // 6. 같은 시간끼리 리스트 만들기
+        // 6-1. data
         List<List<GetReservationResponseDto>> data = new ArrayList<>();
-        // 5-2. 같은 시간 리스트업
+        // 6-2. 같은 시간 리스트업
         List<GetReservationResponseDto> responseDtoList = new ArrayList<>();
         LocalDateTime targetTime = sortedList.get(0).getStartDate();
         for (SortReservationDto sortReservationDto : sortedList) {
-            // 5-2-1. responseDto
+            // 6-2-1. responseDto
             GetReservationResponseDto responseDto = GetReservationResponseDto.builder()
                     .scheduleId(sortReservationDto.getScheduleId())
                     .name(sortReservationDto.getName())
@@ -151,7 +158,7 @@ public class ReservationServiceImpl implements ReservationService{
                     .isReserved(sortReservationDto.isReserved())
                     .price(sortReservationDto.getPrice())
                     .build();
-            // 5-2-1. 같은 시간 리스트업
+            // 6-2-1. 같은 시간 리스트업
             if (!targetTime.equals(sortReservationDto.getStartDate())) {
                 data.add(responseDtoList);
                 responseDtoList = new ArrayList<>();
@@ -159,7 +166,7 @@ public class ReservationServiceImpl implements ReservationService{
             }
             responseDtoList.add(responseDto);
         }
-        // 6. Response
+        // 7. Response
         CustomAPIResponse<List<List<GetReservationResponseDto>>> responseBody = CustomAPIResponse.createSuccess(HttpStatus.OK.value(), data, "예약 조회 완료되었습니다.");
         return ResponseEntity
                 .status(HttpStatus.OK)


### PR DESCRIPTION
### 🌈 Issue 번호
- close #97 

### 📄 변경 사항
구장 에약 일정 조회 API 구현

### 🏆 테스트 결과
#### 200(성공)
<img width="514" alt="image" src="https://github.com/user-attachments/assets/9cf27f13-17d7-417f-ae64-a47c38c6a3dc">

#### 404(경기장 조회 불가)
<img width="557" alt="image" src="https://github.com/user-attachments/assets/fb24ebf0-8ff5-43ec-8fb1-7f84ac78c027">

#### 403(허용되지 않는 날짜)
<img width="523" alt="image" src="https://github.com/user-attachments/assets/022dc9b8-4a7b-485b-ae63-3e66cc8f01f7">

### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
