### PR TITLE
🚨 [Fix] 소셜로그인 - jwt.secret 값 넣을때 발생하는 문제 해결

### DIFF
--- a/scapture/src/main/java/com/server/scapture/oauth/jwt/JwtUtil.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/jwt/JwtUtil.java
@@ -20,8 +20,10 @@ import java.util.Optional;
 @Slf4j
 @Component
 public class JwtUtil {
+    // @Value의 값이 제대로 안 들어가는 오류가 생길 경우, 환경변수에서 jwt.secret 삭제
+    @Value("${jwt.secret}")
+    private String secretKey;
 
-    @Value("${jwt.secret}")private String secretKey;
     @Autowired
     private UserRepository userRepository;
 
@@ -86,7 +88,7 @@ public class JwtUtil {
         return null;
     }
 
-    // 토큰에서 클레임을 추출하는 메서드
+    // 토큰에서 클레임을 추출하는 메서드 -> 토큰의 유효성 검사 (만료시간, 조작여부 등)
     public Claims getClaimsFromToken(String token) {
         try {
             return Jwts.parserBuilder()


### PR DESCRIPTION
환경변수 설정 변경

### 🌈 Issue 번호
- close #81 

### 📄 변경 사항
@Value를 통해 secretKey에 제대로 된 값이 들어가지 않는 문제 해결

- 문제상황
 해당 로그 
2024-07-26T02:42:03.352+09:00  INFO 64568 — [scapture] [           main] com.server.scapture.oauth.jwt.JwtUtil    : Loaded JWT Secret : your_jwt_secret_key
<br>secretKey에 값이 제대로 안 들어감.
-> @Bean 생성 시점과 관련된 의존성 문제는 해결함
-> 다른 팀원들의 로컬에서는 해결됨. 잘 돌아감.
-> 아직 내 로컬에서는 값을 제대로 불러오지 못함.
-> 환경 설정 & applicationsecret.properties 살펴보자

프로젝트 폴더 내에서 정말 많은 경우를 생각해보고 수정, 확인해보았으나

- 로컬 환경변수 문제였음
![image](https://github.com/user-attachments/assets/46d5bf10-d45f-41a2-bcc0-cb4e56217a73)

<br>

- 해당 환경변수들을 지워주고, 저장하고 노트북 껐다 키니 깔끔하게 지워짐!
<img width="392" alt="image" src="https://github.com/user-attachments/assets/e40f8665-a87f-4367-b4d7-13e7901d3fd4">

### 🏆 테스트 결과
@Value 값 넣기 성공!!!
<img width="284" alt="image" src="https://github.com/user-attachments/assets/9368ea52-2da8-43cc-b595-7dd7a311f5fc">
<img width="734" alt="image" src="https://github.com/user-attachments/assets/435629a0-2b8f-496c-ba0d-9f926fb683d9">
-> 이제 테스트 할 때 명시적으로 secretKey의 값을 넣어주고, 커밋 올릴때는 다시 @Value로 바꿔주고 할 필요 없음 😂 

### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
