### PR TITLE
✨ [Feat] 구독 갱신/생성 API 구현

### DIFF
--- a/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
+++ b/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
@@ -14,8 +14,6 @@ import com.server.scapture.subscribe.dto.CreateSubscribeRequestDto;
 public class UserController {
 
     private final UserService userService;
-    private
-
 
     // 프로필 조회
     @GetMapping("/profile")
@@ -39,7 +37,7 @@ public class UserController {
     }
 
     // 구독 생성/갱신
-    @GetMapping("/subscription")
+    @PostMapping("/subscribe")
     public ResponseEntity<CustomAPIResponse<?>> manageSubscription(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader, @RequestBody CreateSubscribeRequestDto createSubscribeRequestDto) {
         return userService.manageSubscribe(authorizationHeader, createSubscribeRequestDto);

--- a/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
+++ b/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.server.scapture.subscribe.dto.CreateSubscribeRequestDto;
 
 @RestController
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private
 
 
     // 프로필 조회
@@ -34,5 +36,12 @@ public class UserController {
     public ResponseEntity<CustomAPIResponse<?>> addBananas(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader, @RequestBody int balance) {
         return userService.addBananas(authorizationHeader, balance);
+    }
+
+    // 구독 생성/갱신
+    @GetMapping("/subscription")
+    public ResponseEntity<CustomAPIResponse<?>> manageSubscription(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader, @RequestBody CreateSubscribeRequestDto createSubscribeRequestDto) {
+        return userService.manageSubscribe(authorizationHeader, createSubscribeRequestDto);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/user/dto/SubscribeResponseDto.java
+++ b/scapture/src/main/java/com/server/scapture/user/dto/SubscribeResponseDto.java
@@ -1,0 +1,20 @@
+package com.server.scapture.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class SubscribeResponseDto {
+
+    private Long subscribeId;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+}

--- a/scapture/src/main/java/com/server/scapture/user/service/UserService.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.server.scapture.user.service;
 
+import com.server.scapture.subscribe.dto.CreateSubscribeRequestDto;
 import com.server.scapture.util.response.CustomAPIResponse;
 import org.springframework.http.ResponseEntity;
 
@@ -12,4 +13,7 @@ public interface UserService {
 
     //프로필 조회
     ResponseEntity<CustomAPIResponse<?>> getProfile(String authorizationHeader);
+
+    // 구독 생성/갱신
+    ResponseEntity<CustomAPIResponse<?>> manageSubscribe(String authorizationHeader, CreateSubscribeRequestDto createSubscribeRequestDto);
 }

--- a/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
@@ -8,6 +8,7 @@ import com.server.scapture.subscribe.repository.SubscribeRepository;
 import com.server.scapture.subscribe.service.SubscribeService;
 import com.server.scapture.user.dto.BananaAddResponseDto;
 import com.server.scapture.user.dto.BananaBalanceResponseDto;
+import com.server.scapture.user.dto.SubscribeResponseDto;
 import com.server.scapture.user.dto.UserProfileDto;
 import com.server.scapture.user.repository.UserRepository;
 import com.server.scapture.util.response.CustomAPIResponse;
@@ -107,10 +108,11 @@ public class UserServiceImpl implements UserService{
         }
         User user = foundUser.get();
 
+        subscribeService.checkRole(); // Subscribe 정보에 따른 User의 Role 확인 및 갱신
+
         Optional<Subscribe> foundSubscribe = subscribeRepository.findByUserId(user.getId());
         UserProfileDto userProfileDto;
 
-        subscribeService.checkRole(); // Subscribe 정보에 따른 Usre의 Role 확인 및 갱신
 
         // 구독중 아닐 시
         if (foundSubscribe.isEmpty()) {
@@ -155,11 +157,32 @@ public class UserServiceImpl implements UserService{
         }
         User user = foundUser.get();
 
+        subscribeService.checkRole(); // Subscribe 정보에 따른 User의 Role 확인 및 갱신
+
+        Optional<Subscribe> foundSubscribe = subscribeRepository.findByUserId(user.getId());
+
+        // 구독 생성 성공 (201) - 구독중이 아닌 경우
+        if (foundSubscribe.isEmpty()) {
+            Subscribe subscribe = Subscribe.builder()
+                    .user(user)
+                    .startDate(createSubscribeRequestDto.convert(true))
+                    .endDate(createSubscribeRequestDto.convert(false))
+                    .build();
+
+            subscribeRepository.save(subscribe);
+
+            SubscribeResponseDto subscribeResponseDto = SubscribeResponseDto.builder()
+                    .subscribeId(subscribe.getId())
+                    .startDate(subscribe.getStartDate())
+                    .endDate(subscribe.getEndDate())
+                    .build();
+
+            CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(201, subscribeResponseDto, "구독 생성이 완료되었습니다.");
+            return ResponseEntity.status(201).body(res);
+        }
 
         // 구독 갱신 성공 (200) - 이미 구독중인 경우
 
-
-        // 구독 생성 성공 (201) - 구독중이 아닌 경우
 
 
         return null;

--- a/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
@@ -146,6 +146,22 @@ public class UserServiceImpl implements UserService{
     // 구독 생성/갱신
     @Override
     public ResponseEntity<CustomAPIResponse<?>> manageSubscribe(String authorizationHeader, CreateSubscribeRequestDto createSubscribeRequestDto) {
+        Optional<User> foundUser = jwtUtil.findUserByJwtToken(authorizationHeader);
+
+        // 회원정보 찾을 수 없음 (404)
+        if (foundUser.isEmpty()) {
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(404, "유효하지 않은 토큰이거나, 해당 ID에 해당하는 회원이 없습니다.");
+            return ResponseEntity.status(401).body(res);
+        }
+        User user = foundUser.get();
+
+
+        // 구독 갱신 성공 (200) - 이미 구독중인 경우
+
+
+        // 구독 생성 성공 (201) - 구독중이 아닌 경우
+
+
         return null;
     }
 }

--- a/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.server.scapture.user.service;
 import com.server.scapture.domain.Subscribe;
 import com.server.scapture.domain.User;
 import com.server.scapture.oauth.jwt.JwtUtil;
+import com.server.scapture.subscribe.dto.CreateSubscribeRequestDto;
 import com.server.scapture.subscribe.repository.SubscribeRepository;
 import com.server.scapture.subscribe.service.SubscribeService;
 import com.server.scapture.user.dto.BananaAddResponseDto;
@@ -140,5 +141,11 @@ public class UserServiceImpl implements UserService{
         CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, userProfileDto, "사용자 정보 조회 완료되었습니다.");
         return ResponseEntity.status(200).body(res);
 
+    }
+
+    // 구독 생성/갱신
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> manageSubscribe(String authorizationHeader, CreateSubscribeRequestDto createSubscribeRequestDto) {
+        return null;
     }
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #119 

### 📄 변경 사항
구독 갱신/생성 - 생성 구현

- 회원 조회 실패 (404)
<img width="601" alt="image" src="https://github.com/user-attachments/assets/26fe63af-e13a-41bb-b16c-896883585e50">

- 구독 생성 성공 (201)
<img width="859" alt="image" src="https://github.com/user-attachments/assets/593eb4d7-f817-432b-a385-b9881f497597">
<img width="694" alt="image" src="https://github.com/user-attachments/assets/724057fe-344a-49e8-a6ab-ac89f0fbd81f">


### 🏆 테스트 결과
ex) API의 경우 명세서에 기재된 사항들 Postman으로 테스트한 결과 첨부

### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
