### PR TITLE
✨ [Feat] 구독 갱신 API 구현 - 갱신 & 구독 생성/갱신에 대한 예외처리 추가

### DIFF
--- a/scapture/src/main/java/com/server/scapture/domain/Subscribe.java
+++ b/scapture/src/main/java/com/server/scapture/domain/Subscribe.java
@@ -27,4 +27,7 @@ public class Subscribe {
         return endDate.format(formatter);
     }
 
+    public void updateEndDate(LocalDateTime newEndDate) {
+        this.endDate = newEndDate;
+    }
 }

--- a/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
+++ b/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
@@ -36,10 +36,17 @@ public class UserController {
         return userService.addBananas(authorizationHeader, balance);
     }
 
-    // 구독 생성/갱신
+    // 구독 생성
     @PostMapping("/subscribe")
-    public ResponseEntity<CustomAPIResponse<?>> manageSubscription(
+    public ResponseEntity<CustomAPIResponse<?>> createSubscribe(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader, @RequestBody CreateSubscribeRequestDto createSubscribeRequestDto) {
-        return userService.manageSubscribe(authorizationHeader, createSubscribeRequestDto);
+        return userService.createSubscribe(authorizationHeader, createSubscribeRequestDto);
+    }
+
+    // 구독 생성
+    @PutMapping("/subscribe")
+    public ResponseEntity<CustomAPIResponse<?>> renewSubscribe(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader) {
+        return userService.extensionSubscribe(authorizationHeader);
     }
 }

--- a/scapture/src/main/java/com/server/scapture/user/service/UserService.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserService.java
@@ -14,6 +14,9 @@ public interface UserService {
     //프로필 조회
     ResponseEntity<CustomAPIResponse<?>> getProfile(String authorizationHeader);
 
-    // 구독 생성/갱신
-    ResponseEntity<CustomAPIResponse<?>> manageSubscribe(String authorizationHeader, CreateSubscribeRequestDto createSubscribeRequestDto);
+    // 구독 생성
+    ResponseEntity<CustomAPIResponse<?>> createSubscribe(String authorizationHeader, CreateSubscribeRequestDto createSubscribeRequestDto);
+
+    // 구독 갱신
+    ResponseEntity<CustomAPIResponse<?>> extensionSubscribe(String authorizationHeader);
 }

--- a/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 
@@ -182,9 +183,20 @@ public class UserServiceImpl implements UserService{
         }
 
         // 구독 갱신 성공 (200) - 이미 구독중인 경우
+        else {
+            Subscribe subscribe = foundSubscribe.get();
+            LocalDateTime newEndDate = subscribe.getEndDate().plusMonths(1); // 한달 추가
+            subscribe.updateEndDate(newEndDate);
+            subscribeRepository.save(subscribe);
 
+            SubscribeResponseDto subscribeResponseDto = SubscribeResponseDto.builder()
+                    .subscribeId(subscribe.getId())
+                    .startDate(subscribe.getStartDate())
+                    .endDate(subscribe.getEndDate())
+                    .build();
 
-
-        return null;
+            CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, subscribeResponseDto, "구독 갱신이 완료되었습니다.");
+            return ResponseEntity.status(200).body(res);
+        }
     }
 }

--- a/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserServiceImpl.java
@@ -146,9 +146,9 @@ public class UserServiceImpl implements UserService{
 
     }
 
-    // 구독 생성/갱신
+    // 구독 생성
     @Override
-    public ResponseEntity<CustomAPIResponse<?>> manageSubscribe(String authorizationHeader, CreateSubscribeRequestDto createSubscribeRequestDto) {
+    public ResponseEntity<CustomAPIResponse<?>> createSubscribe(String authorizationHeader, CreateSubscribeRequestDto createSubscribeRequestDto) {
         Optional<User> foundUser = jwtUtil.findUserByJwtToken(authorizationHeader);
 
         // 회원정보 찾을 수 없음 (404)
@@ -162,41 +162,67 @@ public class UserServiceImpl implements UserService{
 
         Optional<Subscribe> foundSubscribe = subscribeRepository.findByUserId(user.getId());
 
+        // 해당 회원이 이미 구독중인 경우(401)
+        if (foundSubscribe.isPresent()) {
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401, "이미 구독중인 회원입니다.");
+            return ResponseEntity.status(401).body(res);
+        }
+
         // 구독 생성 성공 (201) - 구독중이 아닌 경우
+        Subscribe subscribe = Subscribe.builder()
+                .user(user)
+                .startDate(createSubscribeRequestDto.convert(true))
+                .endDate(createSubscribeRequestDto.convert(false))
+                .build();
+
+        subscribeRepository.save(subscribe);
+
+        SubscribeResponseDto subscribeResponseDto = SubscribeResponseDto.builder()
+                .subscribeId(subscribe.getId())
+                .startDate(subscribe.getStartDate())
+                .endDate(subscribe.getEndDate())
+                .build();
+
+        CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(201, subscribeResponseDto, "구독 생성이 완료되었습니다.");
+        return ResponseEntity.status(201).body(res);
+    }
+
+    // 구독 갱신
+    @Override
+    public ResponseEntity<CustomAPIResponse<?>> extensionSubscribe(String authorizationHeader) {
+        Optional<User> foundUser = jwtUtil.findUserByJwtToken(authorizationHeader);
+
+        // 회원정보 찾을 수 없음 (404)
+        if (foundUser.isEmpty()) {
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(404, "유효하지 않은 토큰이거나, 해당 ID에 해당하는 회원이 없습니다.");
+            return ResponseEntity.status(401).body(res);
+        }
+
+        User user = foundUser.get();
+
+        subscribeService.checkRole(); // Subscribe 정보에 따른 User의 Role 확인 및 갱신
+
+        Optional<Subscribe> foundSubscribe = subscribeRepository.findByUserId(user.getId());
+
+        // 구독중이 아닌 회원의 경우 (401)
         if (foundSubscribe.isEmpty()) {
-            Subscribe subscribe = Subscribe.builder()
-                    .user(user)
-                    .startDate(createSubscribeRequestDto.convert(true))
-                    .endDate(createSubscribeRequestDto.convert(false))
-                    .build();
-
-            subscribeRepository.save(subscribe);
-
-            SubscribeResponseDto subscribeResponseDto = SubscribeResponseDto.builder()
-                    .subscribeId(subscribe.getId())
-                    .startDate(subscribe.getStartDate())
-                    .endDate(subscribe.getEndDate())
-                    .build();
-
-            CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(201, subscribeResponseDto, "구독 생성이 완료되었습니다.");
-            return ResponseEntity.status(201).body(res);
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401, "해당 회원은 구독중이 아닙니다.");
+            return ResponseEntity.status(401).body(res);
         }
 
         // 구독 갱신 성공 (200) - 이미 구독중인 경우
-        else {
-            Subscribe subscribe = foundSubscribe.get();
-            LocalDateTime newEndDate = subscribe.getEndDate().plusMonths(1); // 한달 추가
-            subscribe.updateEndDate(newEndDate);
-            subscribeRepository.save(subscribe);
+        Subscribe subscribe = foundSubscribe.get();
+        LocalDateTime newEndDate = subscribe.getEndDate().plusMonths(1); // 한달 추가
+        subscribe.updateEndDate(newEndDate);
+        subscribeRepository.save(subscribe);
 
-            SubscribeResponseDto subscribeResponseDto = SubscribeResponseDto.builder()
-                    .subscribeId(subscribe.getId())
-                    .startDate(subscribe.getStartDate())
-                    .endDate(subscribe.getEndDate())
-                    .build();
+        SubscribeResponseDto subscribeResponseDto = SubscribeResponseDto.builder()
+                .subscribeId(subscribe.getId())
+                .startDate(subscribe.getStartDate())
+                .endDate(subscribe.getEndDate())
+                .build();
 
-            CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, subscribeResponseDto, "구독 갱신이 완료되었습니다.");
-            return ResponseEntity.status(200).body(res);
-        }
+        CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(201, subscribeResponseDto, "구독 갱신이 완료되었습니다.");
+        return ResponseEntity.status(201).body(res);
     }
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #120 

### 📄 변경 사항
1. 구독 갱신 구현
2. 예외처리 추가
- 구독 갱신 : 구독중이 아닌 회원의 경우 예외처리
- 구독 생성 : 이미 구독중인 경우 예외처리


### 🏆 테스트 결과
1. 구독 갱신
- 회원 조회 실패 (404)
<img width="489" alt="image" src="https://github.com/user-attachments/assets/5ee22919-1dcf-4775-8bcf-09188a00a334">

- 해당 회원이 구독중이 아닌 경우 (401)
<img width="483" alt="image" src="https://github.com/user-attachments/assets/8d6ef7fe-5456-4c09-9ec0-a4859446cc8d">
<img width="336" alt="image" src="https://github.com/user-attachments/assets/7806c727-6867-4f10-ae8c-4ad9c893cd07">

- 구독 갱신 성공 (200)
<img width="389" alt="image" src="https://github.com/user-attachments/assets/99ec8aad-a608-48ca-be73-3019caf4d97a">
<img width="340" alt="image" src="https://github.com/user-attachments/assets/40beb913-fdcf-4306-b16a-fcb416c85d97">

2. 구독 생성 예외처리 추가
- 해당 회원이 이미 구독중인 경우 (401)
<img width="389" alt="image" src="https://github.com/user-attachments/assets/01d951cd-013e-4cf0-8568-3b6586bb90d4">
<img width="316" alt="image" src="https://github.com/user-attachments/assets/1db07f04-09b8-4aa8-ac4b-264dd545ba25">


### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
