### PR TITLE
🚨 [Fix] 소셜로그인 - Role 들어가도록 수정

### DIFF
--- a/scapture/src/main/java/com/server/scapture/oauth/dto/UserInfo.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/dto/UserInfo.java
@@ -14,7 +14,8 @@ public class UserInfo {
     private String email;
     // @Builder.Default //후에 기본값 지정해주기 -> 기본 카카오톡 프로필?
     private String image;
-    private Role role;
+    @Builder.Default
+    private Role role = Role.BASIC;
 
     public User toEntity() {
         return User.builder()


### PR DESCRIPTION
### 🌈 Issue 번호
- close #113 

### 📄 변경 사항
소셜 로그인 - 회원가입 시 Role을  BASIC으로 설정

### 🏆 테스트 결과
- 포스트맨
<img width="844" alt="image" src="https://github.com/user-attachments/assets/385f6e14-21a1-47c4-af51-d29d734494a3">

- DB
<img width="749" alt="image" src="https://github.com/user-attachments/assets/818853e0-0812-4d86-ade0-5a61718bcef0">

### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
