### PR TITLE
♻️ [Refactoring] 구독 생성 갱신 API 병합

### DIFF
--- a/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
+++ b/scapture/src/main/java/com/server/scapture/user/controller/UserController.java
@@ -50,18 +50,11 @@ public class UserController {
         return userService.addBananas(authorizationHeader, balance);
     }
 
-    // 구독 생성
+    // 구독 관리 (생성/갱신)
     @PostMapping("/subscribe")
-    public ResponseEntity<CustomAPIResponse<?>> createSubscribe(
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader, @RequestBody CreateSubscribeRequestDto createSubscribeRequestDto) {
-        return userService.createSubscribe(authorizationHeader, createSubscribeRequestDto);
-    }
-
-    // 구독 갱신
-    @PutMapping("/subscribe")
-    public ResponseEntity<CustomAPIResponse<?>> renewSubscribe(
+    public ResponseEntity<CustomAPIResponse<?>> manageSubscribe(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader) {
-        return userService.extensionSubscribe(authorizationHeader);
+        return userService.manageSubscribe(authorizationHeader);
     }
 
     // 예약 내역 조회

--- a/scapture/src/main/java/com/server/scapture/user/service/UserService.java
+++ b/scapture/src/main/java/com/server/scapture/user/service/UserService.java
@@ -22,12 +22,10 @@ public interface UserService {
     // 프로필 편집
     ResponseEntity<CustomAPIResponse<?>> editProfile(String authorizationHeader, ProfileEditDto profileEditDto, MultipartFile image) throws IOException;
 
-    // 구독 생성
-    ResponseEntity<CustomAPIResponse<?>> createSubscribe(String authorizationHeader, CreateSubscribeRequestDto createSubscribeRequestDto);
-
-    // 구독 갱신
-    ResponseEntity<CustomAPIResponse<?>> extensionSubscribe(String authorizationHeader);
+    // 구독 관리 (생성/갱신)
+    ResponseEntity<CustomAPIResponse<?>> manageSubscribe(String authorizationHeader);
 
     // 예약 내역 조회
     ResponseEntity<CustomAPIResponse<?>> searchReservations(String authorizationHeader);
+
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #176

### 📄 변경 사항
구독 생성 API, 구독 갱신 API 병합

1. 구독 생성 시 (구독중이 아닐 시)
: api를 쏜 시점부터 한달 구독을 생성해준다
- 포스트맨
![image](https://github.com/user-attachments/assets/f33439d4-c01f-4e37-b7e8-ae02b44936ae)

2. 구독 갱신 시 (이미 구독중일 시)
: 이미 구독되어있는 구독의 endDate를 가져와 한 달을 추가해준다.
- 포스트맨
![image](https://github.com/user-attachments/assets/6a9ce532-ca05-4286-92a1-fb4271eb2b62)

- DB 
<img width="525" alt="image" src="https://github.com/user-attachments/assets/8f38ba56-2f57-42c7-ad7a-3da8149cee49">

### 🏆 테스트 결과
ex) API의 경우 명세서에 기재된 사항들 Postman으로 테스트한 결과 첨부

### Reviewer 요구 사항
ex) Reviewer가 확인해줬으면 하는 사항 작성
