### PR TITLE
♻️ [Refact] 소셜로그인 코드 리펙터링

### DIFF
--- a/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/controller/SignController.java
@@ -21,8 +21,6 @@ import java.util.Optional;
 @RequestMapping("api/oauth")
 @RequiredArgsConstructor
 public class SignController {
-    private static final Logger logger = LoggerFactory.getLogger(SignController.class);
-
     private final NaverLoginService naverLoginService;
     private final KakaoLoginService kakaoLoginService;
     private final GoogleLoginService googleLoginService;
@@ -31,7 +29,6 @@ public class SignController {
     @PostMapping(value = "/social/kakao")
     public ResponseEntity<CustomAPIResponse<?>> kakaoLogin(@RequestParam String code) {
         // 1. 인가 코드 받기 (@RequestParam String code)
-        logger.info("Request_Code: {}", code);
         if (code.isEmpty()) {
             return ResponseEntity
                     .status(HttpStatus.FORBIDDEN)
@@ -54,10 +51,6 @@ public class SignController {
         // 4. 로그인/회원가입 후 JWT 토큰 발급
         UserInfo userInfo = (UserInfo) userInfoResponse.getBody().getData(); //후에 서비스 계층 안으로 넣어주기
         //log를 통한 테스트 용도
-        logger.info("User_Email: {}", userInfo.getEmail());
-        logger.info("User_Name: {}", userInfo.getName());
-        logger.info("User_ProviderId: {}", userInfo.getProviderId());
-        logger.info("User_Image: {}", userInfo.getImage());
         ResponseEntity<CustomAPIResponse<?>> loginResponse = kakaoLoginService.login(userInfo);
         if (loginResponse.getBody().getStatus() != 200 || loginResponse.getBody().getStatus() != 201) {
             return ResponseEntity.status(loginResponse.getStatusCode()).body(loginResponse.getBody());
@@ -69,9 +62,6 @@ public class SignController {
     @PostMapping(value = "/social/naver")
     public ResponseEntity<CustomAPIResponse<?>> naverLogin(@RequestParam String code, @RequestParam String state) {
         // 1. 인가 코드 받기 (@RequestParam String code)
-        logger.info("Request_Code: {}", code);
-        logger.info("Request_State: {}", state);
-
         if (code.isEmpty() || state.isEmpty()) {
             return ResponseEntity
                     .status(HttpStatus.FORBIDDEN)
@@ -92,11 +82,7 @@ public class SignController {
 
         // 4. 로그인/회원가입 후 JWT 토큰 발급
         UserInfo userInfo = (UserInfo) userInfoResponse.getBody().getData(); //후에 서비스 계층 안으로 넣어주기
-        //log를 통한 테스트 용도
-        logger.info("User_Email: {}", userInfo.getEmail());
-        logger.info("User_Name: {}", userInfo.getName());
-        logger.info("User_ProviderId: {}", userInfo.getProviderId());
-        logger.info("User_Image: {}", userInfo.getImage());
+
         ResponseEntity<CustomAPIResponse<?>> loginResponse = naverLoginService.login(userInfo);
         if (loginResponse.getBody().getStatus() != 200 || loginResponse.getBody().getStatus() != 201) {
             return ResponseEntity.status(loginResponse.getStatusCode()).body(loginResponse.getBody());
@@ -108,7 +94,6 @@ public class SignController {
     @PostMapping(value = "/social/google")
     public ResponseEntity<CustomAPIResponse<?>> googleLogin(@RequestParam String code) {
         // 1. 인가 코드 받기 (@RequestParam String code)
-        logger.info("Request_Code: {}", code);
         if (code.isEmpty()) {
             return ResponseEntity
                     .status(HttpStatus.FORBIDDEN)
@@ -130,11 +115,7 @@ public class SignController {
 
         // 4. 로그인/회원가입 후 JWT 토큰 발급
         UserInfo userInfo = (UserInfo) userInfoResponse.getBody().getData(); //후에 서비스 계층 안으로 넣어주기
-        //log를 통한 테스트 용도
-        logger.info("User_Email: {}", userInfo.getEmail());
-        logger.info("User_Name: {}", userInfo.getName());
-        logger.info("User_ProviderId: {}", userInfo.getProviderId());
-        logger.info("User_Image: {}", userInfo.getImage());
+
         ResponseEntity<CustomAPIResponse<?>> loginResponse = googleLoginService.login(userInfo);
         if (loginResponse.getBody().getStatus() != 200 || loginResponse.getBody().getStatus() != 201) {
             return ResponseEntity.status(loginResponse.getStatusCode()).body(loginResponse.getBody());

--- a/scapture/src/main/java/com/server/scapture/oauth/service/GoogleLoginServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/GoogleLoginServiceImpl.java
@@ -38,6 +38,7 @@ public class GoogleLoginServiceImpl extends AbstractSocialLoginService implement
 
     @Override
     public ResponseEntity<CustomAPIResponse<?>> getAccessToken(String code, String state) {
+        // POST 요청을 통해 JSON 형식의 요청 본문을 전송해야 함
         String reqUrl = "https://oauth2.googleapis.com/token";
         RestTemplate restTemplate = new RestTemplate();
 
@@ -126,5 +127,4 @@ public class GoogleLoginServiceImpl extends AbstractSocialLoginService implement
             return ResponseEntity.status(400).body(res);
         }
     }
-
 }

--- a/scapture/src/main/java/com/server/scapture/oauth/service/GoogleLoginServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/GoogleLoginServiceImpl.java
@@ -9,8 +9,9 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -37,59 +38,42 @@ public class GoogleLoginServiceImpl extends AbstractSocialLoginService implement
 
     @Override
     public ResponseEntity<CustomAPIResponse<?>> getAccessToken(String code, String state) {
-        String accessToken = null;
         String reqUrl = "https://oauth2.googleapis.com/token";
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("code", code);
+        requestBody.put("client_id", googleClientId);
+        requestBody.put("client_secret", googleClientSecret);
+        requestBody.put("redirect_uri", googleRedirectUri);
+        requestBody.put("grant_type", "authorization_code");
+
+        HttpEntity<String> request = new HttpEntity<>(requestBody.toString(), headers);
 
         try {
-            URL url = new URL(reqUrl);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-
-            conn.setRequestMethod("POST");
-            conn.setRequestProperty("Content-Type", "application/json");
-
-            String requestBody = new JSONObject()
-                    .put("code", code)
-                    .put("client_id", googleClientId)
-                    .put("client_secret", googleClientSecret)
-                    .put("redirect_uri", googleRedirectUri)
-                    .put("grant_type", "authorization_code")
-                    .toString();
-
-            conn.setDoOutput(true);
-            try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()))) {
-                bw.write(requestBody);
-                bw.flush();
-            }
-
-            int responseCode = conn.getResponseCode();
-            logger.info("Token Response Code: {}", responseCode);
-
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(
-                    responseCode >= 200 && responseCode < 300 ? conn.getInputStream() : conn.getErrorStream()))) {
-                String line;
-                StringBuilder responseSb = new StringBuilder();
-                while ((line = br.readLine()) != null) {
-                    responseSb.append(line);
-                }
-                String result = responseSb.toString();
-                logger.info("Token Response Body: {}", result);
-
-                JSONObject jsonObject = new JSONObject(result);
+            ResponseEntity<String> response = restTemplate.exchange(reqUrl, HttpMethod.POST, request, String.class);
+            if (response.getStatusCode() == HttpStatus.OK) {
+                JSONObject jsonObject = new JSONObject(response.getBody());
                 if (jsonObject.has("access_token")) {
-                    accessToken = jsonObject.getString("access_token");
+                    String accessToken = jsonObject.getString("access_token");
+                    CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, accessToken, "접근 토큰을 성공적으로 받았습니다.");
+                    return ResponseEntity.status(200).body(res);
                 } else {
                     CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401, "이미 사용되었거나 유효하지 않은 인가 코드 입니다.");
                     return ResponseEntity.status(401).body(res);
                 }
+            } else {
+                CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(response.getStatusCodeValue(), "접근 토큰을 받는데 실패했습니다.");
+                return ResponseEntity.status(response.getStatusCodeValue()).body(res);
             }
         } catch (Exception e) {
             logger.error("Error getting access token", e);
-            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401, "접근 토큰을 받는데 실패했습니다.");
-            return ResponseEntity.status(401).body(res);
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(500, "접근 토큰을 받는데 실패했습니다.");
+            return ResponseEntity.status(500).body(res);
         }
-
-        CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, accessToken, "접근 토큰을 성공적으로 받았습니다.");
-        return ResponseEntity.status(200).body(res);
     }
 
     @Override

--- a/scapture/src/main/java/com/server/scapture/oauth/service/KakaoLoginServiceImpl.java
+++ b/scapture/src/main/java/com/server/scapture/oauth/service/KakaoLoginServiceImpl.java
@@ -8,8 +8,11 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -38,134 +41,44 @@ public class KakaoLoginServiceImpl extends AbstractSocialLoginService implements
 
     @Override
     public ResponseEntity<CustomAPIResponse<?>> getAccessToken(String code, String state) {
-        String accessToken;
+        String reqUrl = "https://kauth.kakao.com/oauth/token";
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("grant_type", "authorization_code");
+        requestBody.add("client_id", kakaoApiKey);
+        requestBody.add("client_secret", kakaoClientSecret);
+        requestBody.add("redirect_uri", kakaoRedirectUri);
+        requestBody.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(requestBody, headers);
+
         try {
-            URL url = new URL(reqUrl);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-
-            conn.setRequestProperty("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-            conn.setDoOutput(true);
-
-            StringBuilder sb = new StringBuilder();
-            sb.append("grant_type=authorization_code");
-            sb.append("&client_id=").append(kakaoApiKey);
-            sb.append("&client_secret=").append(kakaoClientSecret);
-            sb.append("&redirect_uri=").append(kakaoRedirectUri);
-            sb.append("&code=").append(code);
-
-            try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()))) {
-                bw.write(sb.toString());
-                bw.flush();
-            }
-
-            int responseCode = conn.getResponseCode();
-            logger.info("Token Response Code: {}", responseCode);
-
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(
-                    responseCode >= 200 && responseCode < 300 ? conn.getInputStream() : conn.getErrorStream()))) {
-                String line;
-                StringBuilder responseSb = new StringBuilder();
-                while ((line = br.readLine()) != null) {
-                    responseSb.append(line);
-                }
-                String result = responseSb.toString();
-                logger.info("Token Response Body: {}", result);
-
-                JSONObject jsonObject = new JSONObject(result);
+            ResponseEntity<String> response = restTemplate.exchange(reqUrl, HttpMethod.POST, request, String.class);
+            if (response.getStatusCode() == HttpStatus.OK) {
+                JSONObject jsonObject = new JSONObject(response.getBody());
                 if (jsonObject.has("access_token")) {
-                    accessToken = jsonObject.getString("access_token");
+                    String accessToken = jsonObject.getString("access_token");
+                    CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, accessToken, "접근 토큰을 성공적으로 받았습니다.");
+                    return ResponseEntity.status(200).body(res);
                 } else {
-                    CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401,"이미 사용되었거나 유효하지 않은 인가 코드 입니다.");
+                    CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401, "이미 사용되었거나 유효하지 않은 인가 코드 입니다.");
                     return ResponseEntity.status(401).body(res);
                 }
+            } else {
+                CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(response.getStatusCodeValue(), "접근 토큰을 받는데 실패했습니다.");
+                return ResponseEntity.status(response.getStatusCodeValue()).body(res);
             }
         } catch (Exception e) {
             logger.error("Error getting access token", e);
-            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401,"접근 토큰을 받는데 실패했습니다.");
-            return ResponseEntity.status(401).body(res);
+            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(500, "접근 토큰을 받는데 실패했습니다.");
+            return ResponseEntity.status(500).body(res);
         }
-
-        CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, accessToken, "접근 토큰을 성공적으로 받았습니다.");
-        return ResponseEntity.status(200).body(res);
     }
 
-    @Override
-    public ResponseEntity<CustomAPIResponse<?>> getUserInfo(String accessToken) {
-        String providerId = null;
-        String provider = "kakao";
-        String nickname = null;
-        String email = null;
-        String profileImageUrl = null;
 
-        String reqUrl = "https://kapi.kakao.com/v2/user/me";
-        try {
-            URL url = new URL(reqUrl);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("POST");
-            conn.setRequestProperty("Authorization", "Bearer " + accessToken);
-            conn.setRequestProperty("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
-            int responseCode = conn.getResponseCode();
-            logger.info("Response Code: {}", responseCode);
-
-            if (responseCode == 401) {
-                CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(401, "토큰이 만료되었거나 유효하지 않은 토큰입니다.");
-                return ResponseEntity.status(401).body(res);
-            }
-
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(
-                    responseCode >= 200 && responseCode <= 300 ? conn.getInputStream() : conn.getErrorStream()))) {
-                String line;
-                StringBuilder responseSb = new StringBuilder();
-                while ((line = br.readLine()) != null) {
-                    responseSb.append(line);
-                }
-                String result = responseSb.toString();
-                logger.info("User Info Response Body: {}", result);
-
-                JSONObject jsonObject = new JSONObject(result);
-
-                if (jsonObject.has("id")) {
-                    providerId = String.valueOf(jsonObject.getLong("id"));
-                } else {
-                    logger.warn("No 'id' field in response");
-                }
-
-                if (jsonObject.has("properties")) {
-                    nickname = jsonObject.getJSONObject("properties").optString("nickname", null);
-                } else {
-                    logger.warn("No 'properties' field in response");
-                }
-
-                if (jsonObject.has("kakao_account")) {
-                    JSONObject kakaoAccount = jsonObject.getJSONObject("kakao_account");
-                    email = kakaoAccount.optString("email", null);
-
-                    if (kakaoAccount.has("profile")) {
-                        JSONObject profile = kakaoAccount.getJSONObject("profile");
-                        profileImageUrl = profile.optString("profile_image_url", null);
-                    } else {
-                        logger.warn("No 'profile' field in 'kakao_account'");
-                    }
-                } else {
-                    logger.warn("No 'kakao_account' field in response");
-                }
-            }
-        } catch (Exception e) {
-            logger.error("Error getting user info", e);
-            CustomAPIResponse<?> res = CustomAPIResponse.createFailWithoutData(400, "유저 정보를 가져오는데 실패했습니다.");
-            return ResponseEntity.status(400).body(res);
-        }
-
-        UserInfo userInfo = UserInfo.builder()
-                .provider(provider)
-                .providerId(providerId)
-                .name(nickname)
-                .email(email)
-                .image(profileImageUrl)
-                .build();
-        CustomAPIResponse<?> res = CustomAPIResponse.createSuccess(200, userInfo, "유저 정보를 성공적으로 가져왔습니다.");
-        return ResponseEntity.status(200).body(res);
-    }
     //login()은 모든 소셜 로그인에서 공통됨 -> 추상 클래스로 구현
 }


### PR DESCRIPTION
### 🌈 Issue 번호
- close #170 

### 📄 변경 사항
- 소셜로그인 접근토큰/회원정보 받아오기 로직 HttpURLConnection->RestTemplate
- 로그 제거
- 주석 추가

### 🏆 테스트 결과
1. 카카오 소셜로그인
<img width="263" alt="image" src="https://github.com/user-attachments/assets/74e5085a-dd11-4ce2-854c-f1d875d05156">

2. 네이버 소셜로그인
<img width="488" alt="image" src="https://github.com/user-attachments/assets/38fad016-0ce9-42f6-919d-0bd8045150a2">

3. 구글 소셜로그인
<img width="312" alt="image" src="https://github.com/user-attachments/assets/28357579-2316-4ddd-b354-91afc263d653">

### Reviewer 요구 사항
